### PR TITLE
[BugFix] Guard mixed files() inserts with planner lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -126,6 +126,15 @@ public class QueryAnalyzer {
         new Visitor().process(node, new Scope(RelationId.anonymous(), new RelationFields()));
     }
 
+    /**
+     * Analyze only files() table functions without touching normal table metadata.
+     * This is used to infer files() schema (RPC to BE) without holding PlannerMetaLock,
+     * while deferring normal table analysis to the locked phase.
+     */
+    public void analyzeFilesOnly(StatementBase node) {
+        new FilesOnlyVisitor().process(node, new Scope(RelationId.anonymous(), new RelationFields()));
+    }
+
     public void analyze(StatementBase node, Scope parent) {
         new Visitor().process(node, parent);
     }
@@ -496,6 +505,20 @@ public class QueryAnalyzer {
                 return pivotRelation;
             } else if (relation instanceof FileTableFunctionRelation) {
                 FileTableFunctionRelation tableFunctionRelation = (FileTableFunctionRelation) relation;
+                // If files() was pre-resolved in an unlock phase, reuse it to avoid RPC under lock
+                if (tableFunctionRelation.getTable() instanceof TableFunctionTable) {
+                    TableFunctionTable preResolved = (TableFunctionTable) tableFunctionRelation.getTable();
+                    Consumer<TableFunctionTable> pushDown = tableFunctionRelation.getPushDownSchemaFunc();
+                    if (pushDown != null && !preResolved.isListFilesOnly()) {
+                        pushDown.accept(preResolved);
+                        tableFunctionRelation.setTable(preResolved);
+                    }
+                    if (preResolved.isListFilesOnly()) {
+                        return convertFileTableFunctionRelation(preResolved);
+                    }
+                    return relation;
+                }
+
                 Table table = resolveTableFunctionTable(
                         tableFunctionRelation.getProperties(), tableFunctionRelation.getPushDownSchemaFunc());
                 TableFunctionTable tableFunctionTable = (TableFunctionTable) table;
@@ -1463,6 +1486,93 @@ public class QueryAnalyzer {
             return node.getScope();
         }
 
+    }
+
+    /**
+     * A lightweight visitor that only resolves FileTableFunctionRelation so that
+     * files() schema can be inferred without acquiring DB/table locks. Normal tables/views are skipped.
+     */
+    private class FilesOnlyVisitor implements AstVisitorExtendInterface<Scope, Scope> {
+        public FilesOnlyVisitor() {}
+
+        public Scope process(ParseNode node, Scope scope) {
+            return node.accept(this, scope);
+        }
+
+        @Override
+        public Scope visitQueryStatement(QueryStatement node, Scope parent) {
+            return process(node.getQueryRelation(), parent);
+        }
+
+        @Override
+        public Scope visitQueryRelation(QueryRelation node, Scope parent) {
+            return process(node, parent);
+        }
+
+        @Override
+        public Scope visitSelect(SelectRelation selectRelation, Scope scope) {
+            Relation r = selectRelation.getRelation();
+            // Only touch files(); keep others intact
+            if (r instanceof FileTableFunctionRelation) {
+                FileTableFunctionRelation f = (FileTableFunctionRelation) r;
+                Table table = resolveTableFunctionTable(f.getProperties(), f.getPushDownSchemaFunc());
+                f.setTable(table);
+            } else if (r instanceof JoinRelation) {
+                visitJoin((JoinRelation) r, scope);
+            } else if (r instanceof SubqueryRelation) {
+                visitSubqueryRelation((SubqueryRelation) r, scope);
+            } else if (r instanceof SetOperationRelation) {
+                visitSetOp((SetOperationRelation) r, scope);
+            } else if (r instanceof PivotRelation) {
+                PivotRelation p = (PivotRelation) r;
+                process(p.getQuery(), scope);
+            }
+            return scope;
+        }
+
+        public Scope visitJoin(JoinRelation join, Scope scope) {
+            Relation l = join.getLeft();
+            Relation r = join.getRight();
+            // SubqueryRelation/SetOperationRelation/PivotRelation are intentionally skipped here, because
+            // pre-analyzing them would still require table metadata and locks; the full analyzer pass will
+            // revisit them after files() has been resolved where necessary.
+            if (l instanceof FileTableFunctionRelation) {
+                FileTableFunctionRelation f = (FileTableFunctionRelation) l;
+                f.setTable(resolveTableFunctionTable(f.getProperties(), f.getPushDownSchemaFunc()));
+            } else if (l instanceof JoinRelation) {
+                visitJoin((JoinRelation) l, scope);
+            } else if (l instanceof SelectRelation) {
+                visitSelect((SelectRelation) l, scope);
+            }
+
+            // Same as the left side: we intentionally skip SubqueryRelation, SetOperationRelation and
+            // PivotRelation, leaving them to the main analyzer so that we do not touch normal tables while
+            // under the files-only fast path.
+            if (r instanceof FileTableFunctionRelation) {
+                FileTableFunctionRelation f = (FileTableFunctionRelation) r;
+                Table resolved = resolveTableFunctionTable(f.getProperties(), f.getPushDownSchemaFunc());
+                f.setTable(resolved);
+                // Do NOT mark lateral here: the relation remains a FileTableFunctionRelation, and the main analyzer
+                // will decide whether lateral semantics are required once it has the final relation type.
+            } else if (r instanceof JoinRelation) {
+                visitJoin((JoinRelation) r, scope);
+            } else if (r instanceof SelectRelation) {
+                visitSelect((SelectRelation) r, scope);
+            }
+            return scope;
+        }
+
+        public Scope visitSubqueryRelation(SubqueryRelation subquery, Scope scope) {
+            process(subquery.getQueryStatement(), scope);
+            return scope;
+        }
+
+        public Scope visitSetOp(SetOperationRelation set, Scope scope) {
+            for (QueryRelation qr : set.getRelations()) {
+                process(qr, scope);
+            }
+            return scope;
+        }
     }
 
     public Table resolveTable(TableRelation tableRelation) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
@@ -14,20 +14,38 @@
 
 package com.starrocks.sql;
 
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.TableFunctionTable;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
+import com.starrocks.sql.analyzer.QueryAnalyzer;
+import com.starrocks.sql.ast.FileTableFunctionRelation;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.Relation;
+import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StatementPlannerTest extends PlanTestBase {
@@ -56,6 +74,153 @@ class StatementPlannerTest extends PlanTestBase {
             StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
             PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
             assertTrue(StatementPlanner.analyzeStatement(stmt, connectContext, locker));
+        }
+    }
+
+    @Test
+    public void testFilesTableMixedWithNormalTableForcesLockAndCachesSchema() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            String sql = "insert into t0 select t.v1, t.v2, t.v3 "
+                    + "from files(\"path\"=\"fake://test\", \"format\"=\"csv\") as f "
+                    + "join t0 as t on true";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt);
+
+            List<FileTableFunctionRelation> preRelations =
+                    AnalyzerUtils.collectFileTableFunctionRelation(((InsertStmt) stmt).getQueryStatement());
+            assertEquals(1, preRelations.size());
+            FileTableFunctionRelation relation = preRelations.get(0);
+            Consumer<TableFunctionTable> original = relation.getPushDownSchemaFunc();
+            AtomicInteger analyzeCount = new AtomicInteger();
+            relation.setPushDownSchemaFunc(table -> {
+                analyzeCount.incrementAndGet();
+                if (original != null) {
+                    original.accept(table);
+                }
+            });
+
+            boolean deferred = StatementPlanner.analyzeStatement(stmt, connectContext, locker);
+            assertFalse(deferred);
+
+            List<FileTableFunctionRelation> relations =
+                    AnalyzerUtils.collectFileTableFunctionRelation(((InsertStmt) stmt).getQueryStatement());
+            assertEquals(1, relations.size());
+            assertNotNull(relations.get(0).getTable());
+            // pushDownSchemaFunc runs once during pre-analysis and once again under lock to apply cached schema
+            assertEquals(2, analyzeCount.get());
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+
+    @Test
+    public void testPreAnalyzedFilesTableStillAppliesPushDown() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            String sql = "insert into t0 select 1, 2, 3 "
+                    + "from files(\"path\"=\"fake://test\", \"format\"=\"csv\") as f";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            QueryStatement queryStatement = ((InsertStmt) stmt).getQueryStatement();
+
+            List<FileTableFunctionRelation> relations =
+                    AnalyzerUtils.collectFileTableFunctionRelation(queryStatement);
+            assertEquals(1, relations.size());
+            FileTableFunctionRelation relation = relations.get(0);
+
+            new QueryAnalyzer(connectContext).analyzeFilesOnly(queryStatement);
+            TableFunctionTable tableBefore = (TableFunctionTable) relation.getTable();
+            assertNotNull(tableBefore);
+            assertEquals(2, tableBefore.getFullSchema().size());
+            assertEquals(Type.INT, tableBefore.getFullSchema().get(0).getType());
+
+            AtomicBoolean pushDownApplied = new AtomicBoolean(false);
+            relation.setPushDownSchemaFunc(table -> {
+                pushDownApplied.set(true);
+                List<Column> newSchema = table.getFullSchema().stream()
+                        .map(Column::new)
+                        .collect(Collectors.toList());
+                newSchema.forEach(column -> column.setType(Type.BIGINT));
+                table.setNewFullSchema(newSchema);
+            });
+
+            new QueryAnalyzer(connectContext).analyze(queryStatement);
+
+            TableFunctionTable tableAfter = (TableFunctionTable) relation.getTable();
+            assertTrue(pushDownApplied.get());
+            assertEquals(Type.BIGINT, tableAfter.getFullSchema().get(0).getType());
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+
+    @Test
+    public void testFilesOnlyVisitorDoesNotForceLateralForListing() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            String sql = "select * from (select 1) t cross join "
+                    + "files(\"path\"=\"fake://test\", \"list_files_only\"=\"true\") as f";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            QueryStatement queryStatement = (QueryStatement) stmt;
+            SelectRelation selectRelation = (SelectRelation) queryStatement.getQueryRelation();
+            JoinRelation joinRelation = (JoinRelation) selectRelation.getRelation();
+
+            assertFalse(joinRelation.isLateral());
+
+            new QueryAnalyzer(connectContext).analyzeFilesOnly(queryStatement);
+
+            assertFalse(joinRelation.isLateral());
+            Relation rightAfterFilesOnly = joinRelation.getRight();
+            if (rightAfterFilesOnly instanceof FileTableFunctionRelation) {
+                TableFunctionTable table = (TableFunctionTable) ((FileTableFunctionRelation) rightAfterFilesOnly).getTable();
+                assertNotNull(table);
+                assertTrue(table.isListFilesOnly());
+            } else {
+                assertTrue(rightAfterFilesOnly instanceof ValuesRelation,
+                        "Unexpected right relation after files-only analysis: " + rightAfterFilesOnly.getClass());
+            }
+
+            new QueryAnalyzer(connectContext).analyze(queryStatement);
+
+            assertFalse(joinRelation.isLateral());
+            assertTrue(joinRelation.getRight() instanceof ValuesRelation);
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+
+    @Test
+    public void testFilesOnlyVisitorDoesNotForceLateralForLoad() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            String sql = "select * from (select 1) t join "
+                    + "files(\"path\"=\"fake://test\", \"format\"=\"csv\") as f on true";
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            QueryStatement queryStatement = (QueryStatement) stmt;
+            SelectRelation selectRelation = (SelectRelation) queryStatement.getQueryRelation();
+            JoinRelation joinRelation = (JoinRelation) selectRelation.getRelation();
+
+            assertFalse(joinRelation.isLateral());
+
+            new QueryAnalyzer(connectContext).analyzeFilesOnly(queryStatement);
+
+            assertFalse(joinRelation.isLateral());
+            assertTrue(joinRelation.getRight() instanceof FileTableFunctionRelation);
+            TableFunctionTable table =
+                    (TableFunctionTable) ((FileTableFunctionRelation) joinRelation.getRight()).getTable();
+            assertNotNull(table);
+            assertFalse(table.isListFilesOnly());
+
+            new QueryAnalyzer(connectContext).analyze(queryStatement);
+
+            assertFalse(joinRelation.isLateral());
+            assertTrue(joinRelation.getRight() instanceof FileTableFunctionRelation);
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
         }
     }
 


### PR DESCRIPTION
- pre-analyze files() relations without lock and disable deferred lock when normal tables participate
- reuse cached TableFunctionTable to avoid repeated BE RPCs during locked analysis
- extend StatementPlannerTest to assert schema caching and single files() analysis

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
