### PR TITLE
[BugFix] Fix automatic partition creation failure on duplicate partition values

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -279,8 +279,12 @@ public class CatalogUtils {
         }
     }
 
-    public static void checkPartitionValuesExistForAddListPartition(OlapTable olapTable, PartitionDesc partitionDesc,
-                                                                    boolean isTemp)
+    /**
+     * Check if partition values already exist in the table for list partition.
+     * @return true if partition values already exist (duplicate), false otherwise
+     */
+    public static boolean checkPartitionValuesExistForAddListPartition(OlapTable olapTable, PartitionDesc partitionDesc,
+                                                                       boolean isTemp)
             throws DdlException {
         try {
             ListPartitionInfo listPartitionInfo = (ListPartitionInfo) olapTable.getPartitionInfo();
@@ -291,24 +295,29 @@ public class CatalogUtils {
                 SingleItemListPartitionDesc singleItemListPartitionDesc = (SingleItemListPartitionDesc) partitionDesc;
                 for (LiteralExpr item : singleItemListPartitionDesc.getLiteralExprValues()) {
                     if (existingValues.contains(item)) {
-                        throw new DdlException("Duplicate partition value " + item.getStringValue());
+                        return true;
                     }
                 }
             } else if (partitionDesc instanceof MultiItemListPartitionDesc) {
                 int partitionColSize = listPartitionInfo.getPartitionColumnsSize();
                 MultiItemListPartitionDesc multiItemListPartitionDesc = (MultiItemListPartitionDesc) partitionDesc;
-                checkItemValuesValid(partitionColSize, partitionIds, listPartitionInfo.getMultiLiteralExprValues(),
+                return isItemValuesExist(partitionColSize, partitionIds, listPartitionInfo.getMultiLiteralExprValues(),
                         multiItemListPartitionDesc);
             }
         } catch (AnalysisException e) {
             throw new DdlException(e.getMessage());
         }
+        return false;
     }
 
-    private static void checkItemValuesValid(int partitionColSize, Set<Long> partitionIds,
+    /**
+     * Check if multi-item partition values already exist.
+     * @return true if values already exist (duplicate), false otherwise
+     */
+    private static boolean isItemValuesExist(int partitionColSize, Set<Long> partitionIds,
                                              Map<Long, List<List<LiteralExpr>>> idToMultiLiteralExprValues,
                                              MultiItemListPartitionDesc multiItemListPartitionDesc)
-            throws AnalysisException, DdlException {
+            throws AnalysisException {
         List<Map<LiteralExpr, Set<Long>>> valueToIdIndexList = new ArrayList<>();
         for (int i = 0; i < partitionColSize; ++i) {
             valueToIdIndexList.add(new HashMap<>());
@@ -362,11 +371,11 @@ public class CatalogUtils {
                 }
             }
             if (!isValid) {
-                List<String> multiValues = values.stream().map(LiteralExpr::getStringValue)
-                        .collect(Collectors.toList());
-                throw new DdlException("Duplicate values " + "(" + String.join(",", multiValues) + ") ");
+                // Values already exist (duplicate)
+                return true;
             }
         }
+        return false;
     }
 
     public static int divisibleBucketNum(int backendNum) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -131,6 +131,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -1347,6 +1348,9 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
         if (!partitionInfo.isListPartition()) {
             return;
         }
+        if (partitionDescs.isEmpty()) {
+            return;
+        }
         ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
         boolean addSingleColumnPartition = partitionDescs.get(0) instanceof SingleItemListPartitionDesc;
         if (addSingleColumnPartition &&
@@ -1375,7 +1379,10 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
             properties.putAll(clauseProperties);
         }
 
-        for (PartitionDesc partitionDesc : partitionDescs) {
+        // Use iterator to allow removal during iteration for system-created partitions
+        Iterator<PartitionDesc> iterator = partitionDescs.iterator();
+        while (iterator.hasNext()) {
+            PartitionDesc partitionDesc = iterator.next();
             Map<String, String> cloneProperties = Maps.newHashMap(properties);
             Map<String, String> sourceProperties = partitionDesc.getProperties();
             if (sourceProperties != null && !sourceProperties.isEmpty()) {
@@ -1404,8 +1411,18 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                         .collect(Collectors.toList());
                 PartitionDescAnalyzer.analyze(partitionDesc, columnDefList, cloneProperties);
                 if (!existPartitionNameSet.contains(partitionDesc.getPartitionName())) {
-                    CatalogUtils.checkPartitionValuesExistForAddListPartition(olapTable, partitionDesc,
-                            addPartitionClause.isTempPartition());
+                    boolean isDuplicate = CatalogUtils.checkPartitionValuesExistForAddListPartition(olapTable,
+                            partitionDesc, addPartitionClause.isTempPartition());
+                    if (isDuplicate) {
+                        if (partitionDesc.isSystem()) {
+                            // For system-created partitions (automatic partition), skip if values already exist
+                            iterator.remove();
+                        } else {
+                            // For user-created partitions, throw error
+                            throw new DdlException("Duplicate partition values exist for partition: " +
+                                    partitionDesc.getPartitionName());
+                        }
+                    }
                 }
             } else {
                 throw new DdlException("Only support adding partition to range/list partitioned table");

--- a/test/sql/test_automatic_partition/R/test_automatic_partition_idempotent
+++ b/test/sql/test_automatic_partition/R/test_automatic_partition_idempotent
@@ -1,0 +1,35 @@
+-- name: test_automatic_partition_idempotent
+CREATE TABLE t_idempotent (
+    c1 date NOT NULL,
+    c2 varchar(20),
+    c3 boolean NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(c1, c2)
+PARTITION BY (c1, c3)
+DISTRIBUTED BY HASH(c1)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t_idempotent values ("2025-12-01", "1", true), ("2025-12-01", "0", false);
+-- result:
+-- !result
+select * from t_idempotent order by c2;
+-- result:
+2025-12-01	0	0
+2025-12-01	1	1
+-- !result
+admin set frontend config ("max_load_initial_open_partition_number"="1");
+-- result:
+-- !result
+insert into t_idempotent values ("2025-12-01", "1", true), ("2025-12-01", "0", false);
+-- result:
+-- !result
+select * from t_idempotent order by c2;
+-- result:
+2025-12-01	0	0
+2025-12-01	0	0
+2025-12-01	1	1
+2025-12-01	1	1
+-- !result

--- a/test/sql/test_automatic_partition/T/test_automatic_partition_idempotent
+++ b/test/sql/test_automatic_partition/T/test_automatic_partition_idempotent
@@ -1,0 +1,22 @@
+-- name: test_automatic_partition_idempotent
+CREATE TABLE t_idempotent (
+    c1 date NOT NULL,
+    c2 varchar(20),
+    c3 boolean NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(c1, c2)
+PARTITION BY (c1, c3)
+DISTRIBUTED BY HASH(c1)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t_idempotent values ("2025-12-01", "1", true), ("2025-12-01", "0", false);
+
+select * from t_idempotent order by c2;
+
+admin set frontend config ("max_load_initial_open_partition_number"="1");
+
+insert into t_idempotent values ("2025-12-01", "1", true), ("2025-12-01", "0", false);
+
+select * from t_idempotent order by c2;


### PR DESCRIPTION
## Why I'm doing:

When `max_load_initial_open_partition_number` is set to a small value, automatic partition tables fail on subsequent inserts with same partition values, reporting "Duplicate values" error. This happens because:
1. First insert creates partitions successfully
2. Second insert triggers BE to request partition creation from FE
3. FE detects partition values already exist and throws error

## What I'm doing:

- Add partition value existence check in AnalyzerUtils.getAddPartitionClauseFromPartitionValues
- Normalize BE partition values to FE format (e.g., "1" -> "TRUE" for boolean) to ensure consistent comparison
- When partition value exists, use existing partition name for response to handle calculateUniquePartitionName edge cases
- Change CatalogUtils.checkPartitionValuesExistForAddListPartition to return boolean instead of throwing exception
- Skip duplicate value check for system-created partitions in AlterTableClauseAnalyzer.analyzeAddPartition
- Add empty list guard in upgradeDeprecatedSingleItemListPartitionDesc

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure automatic list-partition creation reuses existing partitions for duplicate values and only errors for user-created duplicates.
> 
> - **Partition handling (List)**:
>   - Change `CatalogUtils.checkPartitionValuesExistForAddListPartition` to return boolean; add `isItemValuesExist` helper to detect duplicates.
>   - In `AlterTableClauseAnalyzer`:
>     - Guard empty partition list in upgrade path; use iterator to allow removals.
>     - On duplicate values: skip system-created partitions; throw for user-created; integrate new boolean API.
>   - In `AnalyzerUtils` (auto list partition):
>     - Normalize incoming values by partition column types for consistent comparison.
>     - Check against existing partitions via `PCell`/`PCellWithName`; reuse existing partition names; avoid creating duplicate descriptors.
> - **Tests**:
>   - Add `test_automatic_partition_idempotent` to verify idempotent behavior with repeated inserts and small `max_load_initial_open_partition_number`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad7db4d7899a2a6a71633d78c84aff24d7d625b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->