### PR TITLE
Verify lake parallel compaction be_tablet_write_log collection

### DIFF
--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -332,7 +332,8 @@ void CompactionScheduler::process_parallel_compaction(const CompactRequest* requ
     for (auto tablet_id : request->tablet_ids()) {
         auto result = _parallel_mgr->create_parallel_tasks(tablet_id, request->txn_id(), request->version(),
                                                            request->parallel_config(), callback,
-                                                           request->force_base_compaction(), _threads.get());
+                                                           request->force_base_compaction(), _threads.get(),
+                                                           request->table_id(), request->partition_id());
 
         if (result.ok()) {
             total_subtasks += result.value();

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -49,6 +49,8 @@ struct TabletParallelState {
     int64_t tablet_id = 0;
     int64_t txn_id = 0;
     int64_t version = 0;
+    int64_t table_id = 0;      // Table ID for tablet write log
+    int64_t partition_id = 0;  // Partition ID for tablet write log
 
     // Rowsets currently being compacted (to avoid conflicts)
     std::unordered_set<uint32_t> compacting_rowsets;
@@ -98,7 +100,7 @@ public:
     StatusOr<int> create_parallel_tasks(int64_t tablet_id, int64_t txn_id, int64_t version,
                                         const TabletParallelConfig& config,
                                         std::shared_ptr<CompactionTaskCallback> callback, bool force_base_compaction,
-                                        ThreadPool* thread_pool);
+                                        ThreadPool* thread_pool, int64_t table_id = 0, int64_t partition_id = 0);
 
     // Get tablet's parallel state (for testing/monitoring)
     TabletParallelState* get_tablet_state(int64_t tablet_id, int64_t txn_id);


### PR DESCRIPTION
## Why I'm doing:

`be_tablet_write_log` was not correctly capturing `table_id` and `partition_id` for lake parallel compaction tasks, as these values were defaulting to 0. This resulted in incomplete and incorrect compaction log entries.

## What I'm doing:

- Added `table_id` and `partition_id` to the `TabletParallelState` struct.
- Modified `create_parallel_tasks` to accept and store `table_id` and `partition_id`.
- Ensured `CompactionTaskContext` is created with the correct `table_id` and `partition_id` during parallel compaction subtasks.
- Updated `compaction_scheduler.cpp` to pass the correct `table_id` and `partition_id` when initiating parallel compaction.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-6b4b7f1b-d07a-42f6-99d1-fa62bb9e55ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6b4b7f1b-d07a-42f6-99d1-fa62bb9e55ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

