### PR TITLE
Hll deserialize crash fix

### DIFF
--- a/be/src/types/hll.h
+++ b/be/src/types/hll.h
@@ -161,7 +161,8 @@ private:
     MemChunk _registers;
 
 private:
-    void _convert_explicit_to_register();
+    // Returns false if memory allocation fails.
+    bool _convert_explicit_to_register();
 
     // update one hash value into this registers
     void _update_registers(uint64_t hash_value) {


### PR DESCRIPTION
## Why I'm doing:

This PR addresses a crash in `HyperLogLog::deserialize` when processing `HLL_DATA_SPARSE`. The crash occurs because `MemChunkAllocator::allocate`'s return value was not checked, leading to a `memset` call on a potentially null or invalid pointer if memory allocation failed.

## What I'm doing:

Added a check for the return status of `MemChunkAllocator::allocate` in `HyperLogLog::deserialize`. If allocation fails, an error status is now returned to prevent dereferencing a null pointer.

Fixes #

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

---
<a href="https://cursor.com/background-agent?bcId=bc-28610a18-e306-4d23-9a3b-71d59174eb72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-28610a18-e306-4d23-9a3b-71d59174eb72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

