### PR TITLE
Parallel compaction sst trigger

### DIFF
--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -136,6 +136,10 @@ private:
     void execute_subtask(int64_t tablet_id, int64_t txn_id, int32_t subtask_id, std::vector<RowsetPtr> input_rowsets,
                          int64_t version, bool force_base_compaction);
 
+    // Execute SST compaction once after all subtasks complete
+    // This is called from get_merged_txn_log to perform unified SST compaction
+    Status execute_sst_compaction(int64_t tablet_id, int64_t version, TxnLogPB* merged_log);
+
     // Generate state key from tablet_id and txn_id
     static std::string make_state_key(int64_t tablet_id, int64_t txn_id) {
         return std::to_string(tablet_id) + "_" + std::to_string(txn_id);


### PR DESCRIPTION
## Why I'm doing:

Currently, each subtask of parallel compaction independently triggers SST (Primary Key Index) compaction. This leads to:
1.  **Redundant work**: Multiple subtasks may attempt to compact the same SST files.
2.  **Conflict**: Output SSTs from different subtasks can overwrite each other, and input SSTs may be duplicated in the merged transaction log.
This behavior is inefficient and can lead to incorrect state management for primary key indexes during parallel compaction.

## What I'm doing:

This PR modifies the parallel compaction process to ensure SST compaction is performed only once, after all subtasks have completed and their transaction logs are merged.
1.  **Skip SST compaction in subtasks**: `CompactionTask::execute_index_major_compaction` now skips SST compaction if it's being executed as part of a parallel compaction subtask (`_context->subtask_id >= 0`).
2.  **Unified SST compaction**: `TabletParallelCompactionManager::get_merged_txn_log` is updated to:
    *   Remove the previous logic of copying SST metadata from individual subtask logs.
    *   Call a new `execute_sst_compaction` method to perform a single, consolidated SST compaction after all subtask logs are merged.
3.  **New method**: Added `TabletParallelCompactionManager::execute_sst_compaction` to encapsulate the logic for performing the unified SST compaction.

Fixes #

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-cdf0944d-6a68-4565-bf66-f5fb6d082772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cdf0944d-6a68-4565-bf66-f5fb6d082772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

