### PR TITLE
Partition optimization conflict

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -416,7 +416,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -2437,8 +2436,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             AddPartitionClause clause = AnalyzerUtils.getAddPartitionClauseFromPartitionValues(
                     olapTable, partitionValues, isTemp, partitionNamePrefix);
 
-            List<String> partitionColNames = getPartitionColNames(clause);
-            if (olapTable.getNumberOfPartitions() + partitionColNames.size() > Config.max_partition_number_per_table) {
+            List<String> partitionNames = getPartitionNames(clause);
+            if (olapTable.getNumberOfPartitions() + partitionNames.size() > Config.max_partition_number_per_table) {
                 throw new AnalysisException("Table " + olapTable.getName() +
                         " automatically created partitions exceeded the maximum limit: " +
                         Config.max_partition_number_per_table + ". You can modify this restriction on by setting" +
@@ -2448,12 +2447,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
     }
 
-    private static List<String> getPartitionColNames(AddPartitionClause addPartitionClause) {
+    private static List<String> getPartitionNames(AddPartitionClause addPartitionClause) {
         PartitionDesc partitionDesc = addPartitionClause.getPartitionDesc();
         if (partitionDesc instanceof RangePartitionDesc) {
-            return ((RangePartitionDesc) partitionDesc).getPartitionColNames();
+            return ((RangePartitionDesc) partitionDesc).getPartitionNames();
         } else if (partitionDesc instanceof ListPartitionDesc) {
-            return ((ListPartitionDesc) partitionDesc).getPartitionColNames();
+            return ((ListPartitionDesc) partitionDesc).getPartitionNames();
         }
         return Lists.newArrayList();
     }
@@ -2575,7 +2574,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                                                                        TransactionState txnState,
                                                                        List<TOlapTablePartition> partitions,
                                                                        List<TTabletLocation> tablets,
-                                                                       List<String> partitionColNames,
+                                                                       List<String> partitionNames,
                                                                        boolean isTemp) {
         TCreatePartitionResult result = new TCreatePartitionResult();
         TStatus errorStatus = new TStatus(RUNTIME_ERROR);
@@ -2587,7 +2586,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             result.setStatus(errorStatus);
             return result;
         }
-        for (String partitionName : partitionColNames) {
+        for (String partitionName : partitionNames) {
             // get partition info from snapshot
             TOlapTablePartition tPartition = txnState.getPartitionNameToTPartition(olapTable.getId()).get(partitionName);
             if (tPartition != null) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why I'm doing:

To resolve merge conflicts between the `optimize_concurrent_create_partition` branch and `main`, specifically adapting the feature branch to recent naming changes in `main`.

## What I'm doing:

- Updated `FrontendServiceImpl.java` to align with `main`'s renaming of `partitionColNames` to `partitionNames` and `getPartitionColNames()` to `getPartitionNames()`.
- Removed an unused `java.util.TreeSet` import from `FrontendServiceImpl.java`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

---
<p><a href="https://cursor.com/agents/bc-57d0e445-5742-4a91-b21e-590d6304244f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57d0e445-5742-4a91-b21e-590d6304244f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->