### PR TITLE
Refactor range split strategy using shared RangeSplitUtils

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -183,6 +183,7 @@ set(STORAGE_FILES
     push_utils.cpp
     primary_key_recover.cpp
     local_primary_key_recover.cpp
+    range_split_utils.cpp
     lake/async_delta_writer.cpp
     lake/compaction_policy.cpp
     lake/compaction_scheduler.cpp

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -2342,13 +2342,13 @@ bool TabletParallelCompactionManager::_can_use_range_split(const std::vector<Row
     return true;
 }
 
-StatusOr<std::vector<TabletParallelCompactionManager::SegmentKeyBound>>
-TabletParallelCompactionManager::_collect_segment_key_bounds(const std::vector<RowsetPtr>& rowsets) {
+StatusOr<std::vector<SegmentKeyBound>> TabletParallelCompactionManager::_collect_segment_key_bounds(
+        const std::vector<RowsetPtr>& rowsets) {
     std::vector<SegmentKeyBound> seg_bounds;
 
     for (const auto& rowset : rowsets) {
         const auto& meta = rowset->metadata();
-        int32_t num_segments = meta.segments_size();
+        int32_t num_segments = meta.segment_metas_size();
         int64_t rowset_data_size = rowset->data_size();
         int64_t rowset_num_rows = rowset->num_rows();
 
@@ -2367,110 +2367,6 @@ TabletParallelCompactionManager::_collect_segment_key_bounds(const std::vector<R
     }
 
     return seg_bounds;
-}
-
-StatusOr<std::vector<VariantTuple>> TabletParallelCompactionManager::_calculate_range_split_boundaries(
-        const std::vector<SegmentKeyBound>& seg_bounds, int32_t target_subtask_count,
-        int64_t target_bytes_per_subtask) {
-    if (seg_bounds.empty() || target_subtask_count <= 1) {
-        return std::vector<VariantTuple>{};
-    }
-
-    // Collect all boundary points and sort them
-    auto comparator = [](const VariantTuple* a, const VariantTuple* b) { return a->compare(*b) < 0; };
-    std::set<const VariantTuple*, decltype(comparator)> ordered_boundaries(comparator);
-    for (const auto& bound : seg_bounds) {
-        ordered_boundaries.insert(&bound.min_key);
-        ordered_boundaries.insert(&bound.max_key);
-    }
-
-    if (ordered_boundaries.size() < 2) {
-        return std::vector<VariantTuple>{};
-    }
-
-    // Build ordered ranges between adjacent boundary points
-    struct RangeInfo {
-        const VariantTuple* min_key;
-        const VariantTuple* max_key;
-        int64_t estimated_bytes = 0;
-    };
-    std::vector<RangeInfo> ordered_ranges;
-    ordered_ranges.reserve(ordered_boundaries.size());
-    const VariantTuple* last_boundary = nullptr;
-    for (const auto* boundary : ordered_boundaries) {
-        if (last_boundary != nullptr) {
-            ordered_ranges.push_back({last_boundary, boundary, 0});
-        }
-        last_boundary = boundary;
-    }
-
-    if (ordered_ranges.empty()) {
-        return std::vector<VariantTuple>{};
-    }
-
-    // Estimate data size in each range by distributing segment data proportionally
-    for (const auto& seg_bound : seg_bounds) {
-        std::vector<RangeInfo*> overlapping;
-        for (auto& range : ordered_ranges) {
-            bool is_last = (&range == &ordered_ranges.back());
-            if (is_last) {
-                if (!(range.max_key->compare(seg_bound.min_key) < 0 ||
-                      range.min_key->compare(seg_bound.max_key) > 0)) {
-                    overlapping.push_back(&range);
-                }
-            } else {
-                if (!(range.max_key->compare(seg_bound.min_key) <= 0 ||
-                      range.min_key->compare(seg_bound.max_key) >= 0)) {
-                    overlapping.push_back(&range);
-                }
-            }
-        }
-
-        if (!overlapping.empty()) {
-            int64_t per_range = seg_bound.data_size / static_cast<int64_t>(overlapping.size());
-            int64_t remainder = seg_bound.data_size % static_cast<int64_t>(overlapping.size());
-            for (size_t i = 0; i < overlapping.size(); i++) {
-                overlapping[i]->estimated_bytes += per_range + (static_cast<int64_t>(i) < remainder ? 1 : 0);
-            }
-        }
-    }
-
-    // Greedy merge: combine adjacent ranges until we reach target_bytes_per_subtask
-    int64_t total_bytes = 0;
-    for (const auto& r : ordered_ranges) {
-        total_bytes += r.estimated_bytes;
-    }
-
-    int32_t actual_subtask_count = std::min(target_subtask_count, static_cast<int32_t>(ordered_ranges.size()));
-    if (actual_subtask_count <= 1) {
-        return std::vector<VariantTuple>{};
-    }
-
-    int64_t actual_target = total_bytes / actual_subtask_count;
-    if (target_bytes_per_subtask > 0) {
-        actual_target = std::min(actual_target, target_bytes_per_subtask);
-    }
-
-    std::vector<VariantTuple> boundaries;
-    int64_t accumulated_bytes = 0;
-
-    for (size_t i = 0; i < ordered_ranges.size(); i++) {
-        accumulated_bytes += ordered_ranges[i].estimated_bytes;
-
-        bool is_last_range = (i == ordered_ranges.size() - 1);
-        int32_t remaining_splits = actual_subtask_count - 1 - static_cast<int32_t>(boundaries.size());
-
-        if (!is_last_range && remaining_splits > 0 && accumulated_bytes >= actual_target) {
-            boundaries.push_back(*ordered_ranges[i].max_key);
-            accumulated_bytes = 0;
-
-            if (static_cast<int32_t>(boundaries.size()) >= actual_subtask_count - 1) {
-                break;
-            }
-        }
-    }
-
-    return boundaries;
 }
 
 OlapTuple TabletParallelCompactionManager::_variant_tuple_to_olap_tuple(const VariantTuple& vt) {
@@ -2503,11 +2399,20 @@ std::vector<SubtaskGroup> TabletParallelCompactionManager::_create_range_split_g
         total_bytes += bound.data_size;
     }
 
-    int32_t target_subtasks = std::min(max_parallel, static_cast<int32_t>((total_bytes + max_bytes_per_subtask - 1) / max_bytes_per_subtask));
+    int32_t target_subtasks =
+            std::min(max_parallel,
+                     static_cast<int32_t>((total_bytes + max_bytes_per_subtask - 1) / max_bytes_per_subtask));
     target_subtasks = std::max(2, target_subtasks);
 
-    // Calculate boundaries
-    auto boundaries_or = _calculate_range_split_boundaries(seg_bounds, target_subtasks, max_bytes_per_subtask);
+    // Use RangeSplitUtils to build ordered ranges and calculate boundaries
+    auto ordered_ranges_or = RangeSplitUtils::build_ordered_ranges(seg_bounds);
+    if (!ordered_ranges_or.ok() || ordered_ranges_or.value().empty()) {
+        VLOG(1) << "Range split: tablet=" << tablet_id << " failed to build ordered ranges, fallback";
+        return {};
+    }
+
+    auto boundaries_or = RangeSplitUtils::calculate_split_boundaries(ordered_ranges_or.value(), target_subtasks,
+                                                                     max_bytes_per_subtask, /*use_num_rows=*/false);
     if (!boundaries_or.ok() || boundaries_or.value().empty()) {
         VLOG(1) << "Range split: tablet=" << tablet_id << " failed to calculate boundaries, fallback";
         return {};

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -27,6 +27,7 @@
 #include "storage/lake/compaction_task_context.h"
 #include "storage/lake/rowset.h"
 #include "storage/olap_tuple.h"
+#include "storage/range_split_utils.h"
 #include "storage/variant_tuple.h"
 
 namespace starrocks {
@@ -368,28 +369,16 @@ private:
     // Range split related functions
     // ================================================================================
 
-    // Segment key bound info for range boundary calculation
-    struct SegmentKeyBound {
-        VariantTuple min_key;
-        VariantTuple max_key;
-        int64_t num_rows = 0;
-        int64_t data_size = 0;
-    };
-
     // Check if range split is applicable for the given rowsets.
     // All segments must have sort_key_min/max metadata.
     static bool _can_use_range_split(const std::vector<RowsetPtr>& rowsets);
 
     // Collect sort key bounds from all segments across all rowsets.
+    // Returns SegmentKeyBound (defined in range_split_utils.h) for each segment.
     static StatusOr<std::vector<SegmentKeyBound>> _collect_segment_key_bounds(const std::vector<RowsetPtr>& rowsets);
 
-    // Calculate range split boundaries. Returns N-1 boundary tuples for N subtasks.
-    // Uses a greedy algorithm based on estimated data distribution.
-    static StatusOr<std::vector<VariantTuple>> _calculate_range_split_boundaries(
-            const std::vector<SegmentKeyBound>& seg_bounds, int32_t target_subtask_count,
-            int64_t target_bytes_per_subtask);
-
     // Create SubtaskGroups using range split strategy.
+    // Uses RangeSplitUtils to calculate boundaries.
     std::vector<SubtaskGroup> _create_range_split_groups(int64_t tablet_id, const std::vector<RowsetPtr>& rowsets,
                                                           int32_t max_parallel, int64_t max_bytes_per_subtask);
 

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -25,6 +25,7 @@
 #include "storage/lake/meta_file.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/range_split_utils.h"
 #include "storage/tablet_range.h"
 #include "storage/variant_tuple.h"
 
@@ -590,248 +591,168 @@ static Status get_tablet_split_ranges(TabletManager* tablet_manager, const Table
         return Status::InvalidArgument("Invalid split count, it is less than 2");
     }
 
-    struct SegmentInfo {
-        uint32_t rowset_id;
-        VariantTuple min;
-        VariantTuple max;
-        Statistic stat;
-    };
-
     const bool use_delvec = is_primary_key(*tablet_metadata) && tablet_metadata->has_delvec_meta();
-    // Collect all segment infos
-    std::vector<SegmentInfo> segment_infos;
+
+    // Step 1: Collect segment key bounds with delvec adjustment and per-rowset source IDs
+    std::vector<SegmentKeyBound> seg_bounds;
+    std::vector<uint32_t> source_ids;
+
     for (const auto& rowset : tablet_metadata->rowsets()) {
         if (rowset.segments_size() != rowset.segment_size_size() ||
             rowset.segments_size() != rowset.segment_metas_size()) {
             return Status::InvalidArgument("Segment metadata is inconsistent with segment list");
         }
         for (int32_t i = 0; i < rowset.segments_size(); ++i) {
-            auto& segment_info = segment_infos.emplace_back();
-            segment_info.rowset_id = rowset.id();
+            SegmentKeyBound bound;
             const auto& segment_meta = rowset.segment_metas(i);
-            RETURN_IF_ERROR(segment_info.min.from_proto(segment_meta.sort_key_min()));
-            RETURN_IF_ERROR(segment_info.max.from_proto(segment_meta.sort_key_max()));
-            segment_info.stat.num_rows = segment_meta.num_rows();
-            segment_info.stat.data_size = rowset.segment_size(i);
+            RETURN_IF_ERROR(bound.min_key.from_proto(segment_meta.sort_key_min()));
+            RETURN_IF_ERROR(bound.max_key.from_proto(segment_meta.sort_key_max()));
+            bound.num_rows = segment_meta.num_rows();
+            bound.data_size = rowset.segment_size(i);
             if (use_delvec) {
                 const uint32_t segment_id = rowset.id() + get_segment_idx(rowset, i);
                 DelVector delvec;
                 LakeIOOptions lake_io_opts{.fill_data_cache = false};
-                auto st = lake::get_del_vec(tablet_manager, *tablet_metadata, segment_id, false, lake_io_opts, &delvec);
+                auto st =
+                        lake::get_del_vec(tablet_manager, *tablet_metadata, segment_id, false, lake_io_opts, &delvec);
                 if (!st.ok()) {
                     LOG(WARNING) << "Failed to get delvec for tablet " << tablet_metadata->id() << ", segment_id "
                                  << segment_id << ", status: " << st;
                     continue;
                 }
-                const int64_t total_rows = segment_info.stat.num_rows;
+                const int64_t total_rows = bound.num_rows;
                 const int64_t deleted_rows = delvec.cardinality();
                 const int64_t live_rows = std::max<int64_t>(0, total_rows - deleted_rows);
-                const int64_t live_size = total_rows > 0 ? segment_info.stat.data_size * live_rows / total_rows : 0;
-                segment_info.stat.num_rows = live_rows;
-                segment_info.stat.data_size = live_size;
+                const int64_t live_size = total_rows > 0 ? bound.data_size * live_rows / total_rows : 0;
+                bound.num_rows = live_rows;
+                bound.data_size = live_size;
             }
+            seg_bounds.push_back(std::move(bound));
+            source_ids.push_back(rowset.id());
         }
     }
 
-    if (segment_infos.empty()) {
+    if (seg_bounds.empty()) {
         return Status::InvalidArgument("No segments found in tablet metadata");
     }
 
-    // Collect all segment range boundaries in order
-    auto comparator = [](const VariantTuple* key1, const VariantTuple* key2) { return key1->compare(*key2) < 0; };
-    std::set<const VariantTuple*, decltype(comparator)> ordered_range_boundaries;
-    for (const auto& segment_info : segment_infos) {
-        ordered_range_boundaries.insert(&segment_info.min);
-        ordered_range_boundaries.insert(&segment_info.max);
-    }
-
-    struct RangeInfo {
-        VariantTuple min;
-        VariantTuple max;
-        Statistic stat;
-        // rowset_id -> rowset stat
-        std::unordered_map<uint32_t, Statistic> rowset_stats;
-    };
-
-    // Build ordered ranges
-    std::vector<RangeInfo> ordered_ranges;
-    ordered_ranges.reserve(ordered_range_boundaries.size());
-    const VariantTuple* last_boundary = nullptr;
-    for (const auto* range_boundary : ordered_range_boundaries) {
-        if (last_boundary != nullptr) {
-            auto& range_info = ordered_ranges.emplace_back();
-            range_info.min = *last_boundary;
-            range_info.max = *range_boundary;
-            range_info.stat.num_rows = 0;
-            range_info.stat.data_size = 0;
-        }
-        last_boundary = range_boundary;
-    }
-
-    if (ordered_ranges.empty()) {
+    // Step 2: Build ordered ranges with data distribution using RangeSplitUtils
+    ASSIGN_OR_RETURN(auto all_ordered_ranges, RangeSplitUtils::build_ordered_ranges(seg_bounds, source_ids));
+    if (all_ordered_ranges.empty()) {
         return Status::InvalidArgument("No split ranges available");
     }
 
-    // Estimate num_rows and data_size in each ordered ranges
-    for (const auto& segment_info : segment_infos) {
-        std::vector<RangeInfo*> overlapping_ranges;
-        for (auto& range_info : ordered_ranges) {
-            if (&range_info != &ordered_ranges.back()) {
-                // Non-last ranges, treat range as [min, max) to avoid double counting on boundaries
-                if (!(range_info.max.compare(segment_info.min) <= 0 || range_info.min.compare(segment_info.max) >= 0)) {
-                    overlapping_ranges.push_back(&range_info);
-                }
-            } else {
-                // The last range, treat range as [min, max]
-                if (!(range_info.max.compare(segment_info.min) < 0 || range_info.min.compare(segment_info.max) > 0)) {
-                    overlapping_ranges.push_back(&range_info);
-                }
-            }
-        }
-
-        if (overlapping_ranges.empty()) {
-            continue;
-        }
-
-        // Divide num rows and data size equally among all overlapping ranges,
-        // we can add more samples to improve the accuracy of estimation in future
-        const auto split_num_rows = segment_info.stat.num_rows / overlapping_ranges.size();
-        const auto remain_num_rows = segment_info.stat.num_rows % overlapping_ranges.size();
-        const auto split_data_size = segment_info.stat.data_size / overlapping_ranges.size();
-        const auto remain_data_size = segment_info.stat.data_size % overlapping_ranges.size();
-        for (size_t i = 0; i < overlapping_ranges.size(); ++i) {
-            auto delta_num_rows = split_num_rows;
-            auto delta_data_size = split_data_size;
-            if (i < remain_num_rows) {
-                ++delta_num_rows;
-            }
-            if (i < remain_data_size) {
-                ++delta_data_size;
-            }
-
-            auto* range_info = overlapping_ranges[i];
-            range_info->stat.num_rows += delta_num_rows;
-            range_info->stat.data_size += delta_data_size;
-
-            auto& rowset_stat = range_info->rowset_stats[segment_info.rowset_id];
-            rowset_stat.num_rows += delta_num_rows;
-            rowset_stat.data_size += delta_data_size;
-        }
-    }
-
-    // Pick tablet overlapped ranges
+    // Step 3: Filter ordered ranges by tablet range
     TabletRange tablet_range;
     RETURN_IF_ERROR(tablet_range.from_proto(tablet_metadata->range()));
-    std::vector<const RangeInfo*> tablet_overlapped_ranges;
-    tablet_overlapped_ranges.reserve(ordered_ranges.size());
-    int64_t total_num_rows = 0;
-    size_t non_empty_ranges = 0;
-    for (const auto& range_info : ordered_ranges) {
-        if (tablet_range.less_than(range_info.min) || tablet_range.greater_than(range_info.max)) {
-            continue;
-        }
-        tablet_overlapped_ranges.push_back(&range_info);
-        total_num_rows += range_info.stat.num_rows;
-        if (range_info.stat.num_rows > 0) {
-            ++non_empty_ranges;
+    std::vector<OrderedRangeInfo> filtered_ranges;
+    filtered_ranges.reserve(all_ordered_ranges.size());
+    for (auto& range_info : all_ordered_ranges) {
+        if (!tablet_range.less_than(range_info.min_key) && !tablet_range.greater_than(range_info.max_key)) {
+            filtered_ranges.push_back(std::move(range_info));
         }
     }
 
-    // Need enough non-empty ranges to form split_count ranges; otherwise fallback.
-    if (non_empty_ranges < split_count) {
+    // Step 4: Calculate split boundaries using row-based splitting
+    int64_t total_num_rows = 0;
+    for (const auto& r : filtered_ranges) {
+        total_num_rows += r.estimated_num_rows;
+    }
+    int64_t avg_num_rows = std::max<int64_t>(1, total_num_rows / split_count);
+
+    ASSIGN_OR_RETURN(auto boundaries,
+                     RangeSplitUtils::calculate_split_boundaries(filtered_ranges, split_count, avg_num_rows,
+                                                                 /*use_num_rows=*/true));
+
+    // Validate boundaries are strictly within the tablet range
+    std::vector<VariantTuple> valid_boundaries;
+    valid_boundaries.reserve(boundaries.size());
+    for (auto& b : boundaries) {
+        if (tablet_range.strictly_contains(b)) {
+            valid_boundaries.push_back(std::move(b));
+        }
+    }
+
+    if (valid_boundaries.empty()) {
         return Status::InvalidArgument("Not enough split ranges available");
     }
 
-    // Calculate split ranges
+    // Step 5: Assemble TabletRangeInfo with per-rowset stats by walking ordered ranges
+    // against the computed boundaries.
     DCHECK(split_ranges.empty());
     split_ranges.reserve(split_count);
-    const int64_t avg_num_rows = std::max<int64_t>(1, total_num_rows / split_count);
-    int64_t acc_num_rows = 0;
-    std::unordered_map<uint32_t, starrocks::lake::Statistic> acc_rowset_stats;
-    last_boundary = nullptr;
-    size_t remaining_non_empty_ranges = non_empty_ranges;
-    for (size_t i = 0; i < tablet_overlapped_ranges.size(); ++i) {
-        const auto* range_info = tablet_overlapped_ranges[i];
-        const bool is_non_empty = range_info->stat.num_rows > 0;
-        acc_num_rows += range_info->stat.num_rows;
-        for (const auto& [rowset_id, stat] : range_info->rowset_stats) {
-            auto& rowset_stat = acc_rowset_stats[rowset_id];
-            rowset_stat.num_rows += stat.num_rows;
-            rowset_stat.data_size += stat.data_size;
+    size_t boundary_idx = 0;
+    std::unordered_map<uint32_t, Statistic> acc_rowset_stats;
+
+    auto emit_split = [&](const TabletRangePB* lower_bound_src, const VariantTuple* upper_bound,
+                          bool use_tablet_upper) {
+        auto& sr = split_ranges.emplace_back();
+        if (lower_bound_src != nullptr) {
+            sr.range.CopyFrom(*lower_bound_src);
+        } else {
+            sr.range = tablet_metadata->range();
         }
 
-        const auto remaining_splits = static_cast<size_t>(split_count) - split_ranges.size();
-        if (is_non_empty && remaining_splits > 0 &&
-            (acc_num_rows >= avg_num_rows || remaining_non_empty_ranges <= remaining_splits)) {
-            const VariantTuple* boundary = &range_info->max;
-            // Advance boundary across empty ranges within tablet range to reach the gap end.
-            for (size_t j = i + 1; j < tablet_overlapped_ranges.size(); ++j) {
-                const auto* next_range = tablet_overlapped_ranges[j];
-                if (next_range->stat.num_rows > 0 || !tablet_range.strictly_contains(next_range->max)) {
-                    break;
-                }
-                boundary = &next_range->max;
-            }
-
-            // Skip invalid boundary to avoid generating empty or overlapping ranges.
-            if ((last_boundary == nullptr || boundary->compare(*last_boundary) > 0) &&
-                tablet_range.strictly_contains(*boundary)) {
-                auto& split_range = split_ranges.emplace_back();
-                if (last_boundary == nullptr) {
-                    // Use lower bound in tablet range
-                    split_range.range = tablet_metadata->range();
-                } else {
-                    last_boundary->to_proto(split_range.range.mutable_lower_bound());
-                    split_range.range.set_lower_bound_included(true);
-                }
-
-                boundary->to_proto(split_range.range.mutable_upper_bound());
-                split_range.range.set_upper_bound_included(false);
-
-                for (const auto& [rowset_id, stat] : acc_rowset_stats) {
-                    auto& rowset_stat = split_range.rowset_stats[rowset_id];
-                    rowset_stat.num_rows = stat.num_rows;
-                    rowset_stat.data_size = stat.data_size;
-                }
-
-                acc_num_rows = 0;
-                acc_rowset_stats.clear();
-                last_boundary = boundary;
+        if (upper_bound != nullptr && !use_tablet_upper) {
+            upper_bound->to_proto(sr.range.mutable_upper_bound());
+            sr.range.set_upper_bound_included(false);
+        } else if (use_tablet_upper) {
+            if (tablet_metadata->range().has_upper_bound()) {
+                sr.range.mutable_upper_bound()->CopyFrom(tablet_metadata->range().upper_bound());
+                sr.range.set_upper_bound_included(tablet_metadata->range().upper_bound_included());
+            } else {
+                sr.range.clear_upper_bound();
+                sr.range.clear_upper_bound_included();
             }
         }
 
-        if (is_non_empty) {
-            --remaining_non_empty_ranges;
+        for (const auto& [rowset_id, stat] : acc_rowset_stats) {
+            auto& rs = sr.rowset_stats[rowset_id];
+            rs.num_rows = stat.num_rows;
+            rs.data_size = stat.data_size;
+        }
+        acc_rowset_stats.clear();
+    };
+
+    const VariantTuple* last_boundary = nullptr;
+    for (const auto& range : filtered_ranges) {
+        // Accumulate per-rowset stats
+        for (const auto& [source_id, stats_pair] : range.source_stats) {
+            auto& rowset_stat = acc_rowset_stats[source_id];
+            rowset_stat.num_rows += stats_pair.first;
+            rowset_stat.data_size += stats_pair.second;
+        }
+
+        // Check if we've crossed a boundary
+        if (boundary_idx < valid_boundaries.size() &&
+            range.max_key.compare(valid_boundaries[boundary_idx]) >= 0) {
+            TabletRangePB lower_pb;
+            TabletRangePB* lower_src = nullptr;
+            if (last_boundary != nullptr) {
+                last_boundary->to_proto(lower_pb.mutable_lower_bound());
+                lower_pb.set_lower_bound_included(true);
+                lower_src = &lower_pb;
+            }
+            emit_split(lower_src, &valid_boundaries[boundary_idx], false);
+            last_boundary = &valid_boundaries[boundary_idx];
+            boundary_idx++;
         }
     }
 
-    if (split_ranges.size() == split_count) {
-        auto& split_range = split_ranges.back();
-        if (tablet_metadata->range().has_upper_bound()) {
-            split_range.range.mutable_upper_bound()->CopyFrom(tablet_metadata->range().upper_bound());
-            split_range.range.set_upper_bound_included(tablet_metadata->range().upper_bound_included());
-        } else {
-            split_range.range.clear_upper_bound();
-            split_range.range.clear_upper_bound_included();
+    // Emit the last split (from last boundary to tablet upper bound)
+    if (!acc_rowset_stats.empty() || split_ranges.size() < static_cast<size_t>(split_count)) {
+        TabletRangePB lower_pb;
+        TabletRangePB* lower_src = nullptr;
+        if (last_boundary != nullptr) {
+            last_boundary->to_proto(lower_pb.mutable_lower_bound());
+            lower_pb.set_lower_bound_included(true);
+            lower_src = &lower_pb;
         }
-        for (const auto& [rowset_id, stat] : acc_rowset_stats) {
-            auto& rowset_stat = split_range.rowset_stats[rowset_id];
-            rowset_stat.num_rows += stat.num_rows;
-            rowset_stat.data_size += stat.data_size;
-        }
-    } else if (split_ranges.size() + 1 == split_count && acc_num_rows > 0) {
-        auto& split_range = split_ranges.emplace_back();
-        // Use upper bound in tablet range
-        split_range.range = tablet_metadata->range();
-        // Lower bound use the upper bound of previous range
-        split_range.range.mutable_lower_bound()->CopyFrom(split_ranges[split_count - 2].range.upper_bound());
-        split_range.range.set_lower_bound_included(true);
-        for (const auto& [rowset_id, stat] : acc_rowset_stats) {
-            auto& rowset_stat = split_range.rowset_stats[rowset_id];
-            rowset_stat.num_rows = stat.num_rows;
-            rowset_stat.data_size = stat.data_size;
-        }
-    } else {
+        emit_split(lower_src, nullptr, true);
+    }
+
+    if (split_ranges.size() < 2) {
+        split_ranges.clear();
         return Status::InvalidArgument("Not enough split ranges available");
     }
 

--- a/be/src/storage/range_split_utils.cpp
+++ b/be/src/storage/range_split_utils.cpp
@@ -1,0 +1,201 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/range_split_utils.h"
+
+#include <algorithm>
+#include <set>
+
+namespace starrocks {
+
+StatusOr<std::vector<OrderedRangeInfo>> RangeSplitUtils::build_ordered_ranges(
+        const std::vector<SegmentKeyBound>& seg_bounds, const std::vector<uint32_t>& source_ids) {
+    if (seg_bounds.empty()) {
+        return std::vector<OrderedRangeInfo>{};
+    }
+
+    DCHECK(source_ids.empty() || source_ids.size() == seg_bounds.size());
+    bool track_sources = !source_ids.empty();
+
+    // Step 1: Collect all unique boundary points and sort them
+    auto comparator = [](const VariantTuple* a, const VariantTuple* b) { return a->compare(*b) < 0; };
+    std::set<const VariantTuple*, decltype(comparator)> ordered_boundaries(comparator);
+    for (const auto& bound : seg_bounds) {
+        ordered_boundaries.insert(&bound.min_key);
+        ordered_boundaries.insert(&bound.max_key);
+    }
+
+    if (ordered_boundaries.size() < 2) {
+        return std::vector<OrderedRangeInfo>{};
+    }
+
+    // Step 2: Build ordered ranges between adjacent boundary points
+    std::vector<OrderedRangeInfo> ordered_ranges;
+    ordered_ranges.reserve(ordered_boundaries.size());
+    const VariantTuple* last_boundary = nullptr;
+    for (const auto* boundary : ordered_boundaries) {
+        if (last_boundary != nullptr) {
+            OrderedRangeInfo range;
+            range.min_key = *last_boundary;
+            range.max_key = *boundary;
+            ordered_ranges.push_back(std::move(range));
+        }
+        last_boundary = boundary;
+    }
+
+    if (ordered_ranges.empty()) {
+        return ordered_ranges;
+    }
+
+    // Step 3: Estimate data distribution by distributing segment data proportionally
+    // across overlapping ranges.
+    //
+    // For overlap detection:
+    //   - Non-last ranges are treated as [min, max) to avoid double-counting on boundaries
+    //   - The last range is treated as [min, max] to include the rightmost boundary
+    for (size_t seg_idx = 0; seg_idx < seg_bounds.size(); seg_idx++) {
+        const auto& seg_bound = seg_bounds[seg_idx];
+
+        std::vector<OrderedRangeInfo*> overlapping;
+        for (auto& range : ordered_ranges) {
+            bool is_last = (&range == &ordered_ranges.back());
+            if (is_last) {
+                // Last range: [min, max] (inclusive both sides)
+                if (!(range.max_key.compare(seg_bound.min_key) < 0 ||
+                      range.min_key.compare(seg_bound.max_key) > 0)) {
+                    overlapping.push_back(&range);
+                }
+            } else {
+                // Non-last ranges: [min, max) (exclusive right)
+                if (!(range.max_key.compare(seg_bound.min_key) <= 0 ||
+                      range.min_key.compare(seg_bound.max_key) >= 0)) {
+                    overlapping.push_back(&range);
+                }
+            }
+        }
+
+        if (overlapping.empty()) {
+            continue;
+        }
+
+        auto count = static_cast<int64_t>(overlapping.size());
+
+        // Distribute num_rows
+        int64_t rows_per_range = seg_bound.num_rows / count;
+        int64_t rows_remainder = seg_bound.num_rows % count;
+
+        // Distribute data_size
+        int64_t size_per_range = seg_bound.data_size / count;
+        int64_t size_remainder = seg_bound.data_size % count;
+
+        for (int64_t i = 0; i < count; i++) {
+            int64_t delta_rows = rows_per_range + (i < rows_remainder ? 1 : 0);
+            int64_t delta_size = size_per_range + (i < size_remainder ? 1 : 0);
+
+            overlapping[i]->estimated_num_rows += delta_rows;
+            overlapping[i]->estimated_data_size += delta_size;
+
+            if (track_sources) {
+                auto& stats = overlapping[i]->source_stats[source_ids[seg_idx]];
+                stats.first += delta_rows;
+                stats.second += delta_size;
+            }
+        }
+    }
+
+    return ordered_ranges;
+}
+
+StatusOr<std::vector<VariantTuple>> RangeSplitUtils::calculate_split_boundaries(
+        const std::vector<OrderedRangeInfo>& ordered_ranges, int32_t target_split_count,
+        int64_t target_value_per_split, bool use_num_rows) {
+    if (ordered_ranges.empty() || target_split_count <= 1) {
+        return std::vector<VariantTuple>{};
+    }
+
+    // Calculate total value and count non-empty ranges
+    int64_t total_value = 0;
+    size_t non_empty_ranges = 0;
+    for (const auto& r : ordered_ranges) {
+        int64_t val = use_num_rows ? r.estimated_num_rows : r.estimated_data_size;
+        total_value += val;
+        if (val > 0) {
+            non_empty_ranges++;
+        }
+    }
+
+    int32_t actual_split_count =
+            std::min(target_split_count, static_cast<int32_t>(ordered_ranges.size()));
+    if (actual_split_count <= 1) {
+        return std::vector<VariantTuple>{};
+    }
+
+    // Need enough non-empty ranges to form actual_split_count splits
+    if (non_empty_ranges < static_cast<size_t>(actual_split_count)) {
+        return std::vector<VariantTuple>{};
+    }
+
+    int64_t actual_target = total_value / actual_split_count;
+    if (target_value_per_split > 0) {
+        actual_target = std::min(actual_target, target_value_per_split);
+    }
+    actual_target = std::max<int64_t>(1, actual_target);
+
+    std::vector<VariantTuple> boundaries;
+    int64_t accumulated = 0;
+    size_t remaining_non_empty = non_empty_ranges;
+
+    for (size_t i = 0; i < ordered_ranges.size(); i++) {
+        const auto& range = ordered_ranges[i];
+        int64_t val = use_num_rows ? range.estimated_num_rows : range.estimated_data_size;
+        bool is_non_empty = val > 0;
+
+        accumulated += val;
+
+        bool is_last_range = (i == ordered_ranges.size() - 1);
+        int32_t remaining_splits = actual_split_count - 1 - static_cast<int32_t>(boundaries.size());
+
+        if (!is_last_range && remaining_splits > 0 && is_non_empty &&
+            (accumulated >= actual_target ||
+             remaining_non_empty <= static_cast<size_t>(remaining_splits))) {
+            // Advance boundary across trailing empty ranges to maximize natural gaps
+            const VariantTuple* boundary = &range.max_key;
+            for (size_t j = i + 1; j < ordered_ranges.size(); j++) {
+                int64_t next_val = use_num_rows ? ordered_ranges[j].estimated_num_rows
+                                                : ordered_ranges[j].estimated_data_size;
+                if (next_val > 0 || j == ordered_ranges.size() - 1) {
+                    break;
+                }
+                boundary = &ordered_ranges[j].max_key;
+                // Skip these empty ranges in the outer loop
+                i = j;
+            }
+
+            boundaries.push_back(*boundary);
+            accumulated = 0;
+
+            if (static_cast<int32_t>(boundaries.size()) >= actual_split_count - 1) {
+                break;
+            }
+        }
+
+        if (is_non_empty) {
+            remaining_non_empty--;
+        }
+    }
+
+    return boundaries;
+}
+
+} // namespace starrocks

--- a/be/src/storage/range_split_utils.h
+++ b/be/src/storage/range_split_utils.h
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+#include "common/statusor.h"
+#include "storage/variant_tuple.h"
+
+namespace starrocks {
+
+// Segment-level key bound information for range split boundary calculation.
+// Represents one segment's sort key range and data statistics.
+struct SegmentKeyBound {
+    VariantTuple min_key;
+    VariantTuple max_key;
+    int64_t num_rows = 0;
+    int64_t data_size = 0;
+};
+
+// A range between two adjacent boundary points with estimated data statistics.
+struct OrderedRangeInfo {
+    VariantTuple min_key;
+    VariantTuple max_key;
+    int64_t estimated_num_rows = 0;
+    int64_t estimated_data_size = 0;
+    // Per-source statistics (e.g., per-rowset). Key semantics defined by caller.
+    std::unordered_map<uint32_t, std::pair<int64_t, int64_t>> source_stats; // source_id -> (num_rows, data_size)
+};
+
+// Utilities for splitting data ranges by sort key boundaries.
+// Shared by tablet resharding and parallel compaction range split.
+class RangeSplitUtils {
+public:
+    // Build ordered ranges between adjacent boundary points from segment key bounds,
+    // and estimate data distribution across those ranges.
+    //
+    // Each SegmentKeyBound optionally carries a source_id (e.g., rowset_id) for
+    // per-source statistics tracking. Use source_ids.empty() to skip per-source tracking.
+    //
+    // Returns ordered ranges with estimated num_rows and data_size.
+    static StatusOr<std::vector<OrderedRangeInfo>> build_ordered_ranges(
+            const std::vector<SegmentKeyBound>& seg_bounds,
+            const std::vector<uint32_t>& source_ids = std::vector<uint32_t>{});
+
+    // Calculate split boundaries using a greedy algorithm.
+    // Merges adjacent ordered ranges until reaching the target value per split.
+    //
+    // Parameters:
+    //   ordered_ranges: ordered ranges from build_ordered_ranges()
+    //   target_split_count: desired number of splits (N splits => N-1 boundaries)
+    //   target_value_per_split: target data size (or row count) per split
+    //   use_num_rows: if true, use num_rows as the split metric; otherwise use data_size
+    //
+    // Returns N-1 boundary VariantTuples for N splits, or empty if splitting is not possible.
+    //
+    // Improvements over the simple greedy approach:
+    //   - Guarantees split_count boundaries when possible by forcing splits when
+    //     remaining non-empty ranges <= remaining splits needed
+    //   - Advances boundaries across empty ranges to maximize natural gaps
+    static StatusOr<std::vector<VariantTuple>> calculate_split_boundaries(
+            const std::vector<OrderedRangeInfo>& ordered_ranges, int32_t target_split_count,
+            int64_t target_value_per_split, bool use_num_rows = false);
+};
+
+} // namespace starrocks

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -25,6 +25,7 @@
 #include "common/thread/threadpool.h"
 #include "storage/datum_variant.h"
 #include "storage/lake/compaction_scheduler.h"
+#include "storage/range_split_utils.h"
 #include "storage/lake/compaction_task_context.h"
 #include "storage/lake/test_util.h"
 #include "storage/lake/versioned_tablet.h"
@@ -4415,32 +4416,36 @@ TEST_F(TabletParallelCompactionManagerTest, test_calculate_range_split_boundarie
     // 3 segments: [0,15], [10,25], [20,35]
     // Boundaries: 0, 10, 15, 20, 25, 35
     // Ranges: [0,10), [10,15), [15,20), [20,25), [25,35]
-    using SegBound = TabletParallelCompactionManager::SegmentKeyBound;
-    std::vector<SegBound> seg_bounds;
+    std::vector<SegmentKeyBound> seg_bounds;
 
-    SegBound b0;
+    SegmentKeyBound b0;
     b0.min_key = make_variant_int(0);
     b0.max_key = make_variant_int(15);
     b0.data_size = 3000;
     b0.num_rows = 300;
     seg_bounds.push_back(std::move(b0));
 
-    SegBound b1;
+    SegmentKeyBound b1;
     b1.min_key = make_variant_int(10);
     b1.max_key = make_variant_int(25);
     b1.data_size = 3000;
     b1.num_rows = 300;
     seg_bounds.push_back(std::move(b1));
 
-    SegBound b2;
+    SegmentKeyBound b2;
     b2.min_key = make_variant_int(20);
     b2.max_key = make_variant_int(35);
     b2.data_size = 3000;
     b2.num_rows = 300;
     seg_bounds.push_back(std::move(b2));
 
+    // Build ordered ranges and calculate boundaries via RangeSplitUtils
+    auto ordered_ranges_or = RangeSplitUtils::build_ordered_ranges(seg_bounds);
+    ASSERT_TRUE(ordered_ranges_or.ok());
+
     // Target 3 subtasks, 3000 bytes each
-    auto result = TabletParallelCompactionManager::_calculate_range_split_boundaries(seg_bounds, 3, 3000);
+    auto result =
+            RangeSplitUtils::calculate_split_boundaries(ordered_ranges_or.value(), 3, 3000, /*use_num_rows=*/false);
     ASSERT_TRUE(result.ok());
     auto& boundaries = result.value();
 
@@ -4449,24 +4454,31 @@ TEST_F(TabletParallelCompactionManagerTest, test_calculate_range_split_boundarie
 }
 
 TEST_F(TabletParallelCompactionManagerTest, test_calculate_range_split_boundaries_single_subtask) {
-    using SegBound = TabletParallelCompactionManager::SegmentKeyBound;
-    std::vector<SegBound> seg_bounds;
+    std::vector<SegmentKeyBound> seg_bounds;
 
-    SegBound b0;
+    SegmentKeyBound b0;
     b0.min_key = make_variant_int(0);
     b0.max_key = make_variant_int(100);
     b0.data_size = 1000;
     b0.num_rows = 100;
     seg_bounds.push_back(std::move(b0));
 
-    auto result = TabletParallelCompactionManager::_calculate_range_split_boundaries(seg_bounds, 1, 5000);
+    auto ordered_ranges_or = RangeSplitUtils::build_ordered_ranges(seg_bounds);
+    ASSERT_TRUE(ordered_ranges_or.ok());
+
+    auto result =
+            RangeSplitUtils::calculate_split_boundaries(ordered_ranges_or.value(), 1, 5000, /*use_num_rows=*/false);
     ASSERT_TRUE(result.ok());
     EXPECT_TRUE(result.value().empty());
 }
 
 TEST_F(TabletParallelCompactionManagerTest, test_calculate_range_split_boundaries_empty_segments) {
-    std::vector<TabletParallelCompactionManager::SegmentKeyBound> empty;
-    auto result = TabletParallelCompactionManager::_calculate_range_split_boundaries(empty, 3, 3000);
+    std::vector<SegmentKeyBound> empty;
+    auto ordered_ranges_or = RangeSplitUtils::build_ordered_ranges(empty);
+    ASSERT_TRUE(ordered_ranges_or.ok());
+
+    auto result =
+            RangeSplitUtils::calculate_split_boundaries(ordered_ranges_or.value(), 3, 3000, /*use_num_rows=*/false);
     ASSERT_TRUE(result.ok());
     EXPECT_TRUE(result.value().empty());
 }


### PR DESCRIPTION
Extract the common range split algorithm (boundary collection, ordered range building, data distribution estimation, and greedy boundary calculation) from both tablet_parallel_compaction_manager and tablet_reshard into a shared RangeSplitUtils utility class.

Key changes:
- New RangeSplitUtils class in storage/range_split_utils.{h,cpp} with:
  - build_ordered_ranges(): builds ordered ranges between boundary points and estimates data distribution, with optional per-source stats tracking
  - calculate_split_boundaries(): greedy split with guarantees on split count and empty range advancement
- Shared SegmentKeyBound and OrderedRangeInfo structs replace per-module types
- tablet_parallel_compaction_manager: removed _calculate_range_split_boundaries, now uses RangeSplitUtils in _create_range_split_groups
- tablet_reshard: get_tablet_split_ranges now uses RangeSplitUtils for range building and boundary calculation, keeping reshard-specific logic (delvec adjustment, tablet range filtering, TabletRangeInfo assembly) in place
- Tests updated to use RangeSplitUtils API directly

https://claude.ai/code/session_01317Y1h2QyzjDYafVYKJUXB

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
