### PR TITLE
Fix three review issues in range-split parallel compaction

### DIFF
--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1004,8 +1004,15 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
                     for (int i = 0; i < output.segment_encryption_metas_size(); i++) {
                         merged_output->add_segment_encryption_metas(output.segment_encryption_metas(i));
                     }
+                    // Renumber segment_idx sequentially across subtasks.
+                    // Each subtask assigns segment_idx starting from 0, so direct CopyFrom
+                    // would produce duplicate indices. The global RSSID is rowset_id +
+                    // segment_idx, so duplicates cause RSSID collisions in PK tables.
+                    uint32_t seg_idx_base = static_cast<uint32_t>(merged_output->segment_metas_size());
                     for (int i = 0; i < output.segment_metas_size(); i++) {
-                        merged_output->add_segment_metas()->CopyFrom(output.segment_metas(i));
+                        auto* sm = merged_output->add_segment_metas();
+                        sm->CopyFrom(output.segment_metas(i));
+                        sm->set_segment_idx(seg_idx_base + static_cast<uint32_t>(i));
                     }
                     total_num_rows += output.num_rows();
                     total_data_size += output.data_size();
@@ -1031,7 +1038,9 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
                 merged_output->set_num_rows(total_num_rows);
                 merged_output->set_data_size(total_data_size);
                 merged_output->set_overlapped(false);
-                merged_output->set_next_compaction_offset(merged_output->segments_size());
+                // next_compaction_offset must only be set > 0 when overlapped=true.
+                // For non-overlapped range-split output, leave it unset (defaults to 0).
+                merged_output->clear_next_compaction_offset();
             }
 
             op_parallel->set_is_range_split(true);
@@ -1210,9 +1219,16 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
                     for (int i = 0; i < output.segment_encryption_metas_size(); i++) {
                         merged_output->add_segment_encryption_metas(output.segment_encryption_metas(i));
                     }
-                    // Add segment_metas
-                    for (int i = 0; i < output.segment_metas_size(); i++) {
-                        merged_output->add_segment_metas()->CopyFrom(output.segment_metas(i));
+                    // Add segment_metas, renumbering segment_idx sequentially.
+                    // Each subtask assigns segment_idx starting from 0; direct CopyFrom
+                    // would produce duplicate indices and RSSID collisions in PK tables.
+                    {
+                        uint32_t seg_idx_base = static_cast<uint32_t>(merged_output->segment_metas_size());
+                        for (int i = 0; i < output.segment_metas_size(); i++) {
+                            auto* sm = merged_output->add_segment_metas();
+                            sm->CopyFrom(output.segment_metas(i));
+                            sm->set_segment_idx(seg_idx_base + static_cast<uint32_t>(i));
+                        }
                     }
 
                     total_num_rows += output.num_rows();

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <functional>
+#include <gtest/gtest_prod.h>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -390,6 +391,15 @@ private:
 
     // Convert VariantTuple to OlapTuple for TabletReaderParams.
     static OlapTuple _variant_tuple_to_olap_tuple(const VariantTuple& vt);
+
+    // Test access to private methods
+    FRIEND_TEST(TabletParallelCompactionManagerTest, test_can_use_range_split_empty_rowsets);
+    FRIEND_TEST(TabletParallelCompactionManagerTest, test_can_use_range_split_missing_segment_metas);
+    FRIEND_TEST(TabletParallelCompactionManagerTest, test_can_use_range_split_with_segment_metas);
+    FRIEND_TEST(TabletParallelCompactionManagerTest, test_collect_segment_key_bounds);
+    FRIEND_TEST(TabletParallelCompactionManagerTest, test_variant_tuple_to_olap_tuple);
+    FRIEND_TEST(TabletParallelCompactionManagerTest, test_variant_tuple_to_olap_tuple_empty);
+    FRIEND_TEST(TabletParallelCompactionManagerTest, test_create_range_split_groups);
 
     TabletManager* _tablet_mgr;
 

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -4560,7 +4560,7 @@ TEST_F(TabletParallelCompactionManagerTest, test_get_merged_txn_log_range_split)
 
     _manager->register_tablet_state_for_test(tablet_id, txn_id, state);
 
-    // Simulate 3 successful range split subtasks
+    // Simulate 3 successful range split subtasks, each with one segment_meta (idx=0)
     for (int i = 0; i < 3; i++) {
         auto ctx = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
         ctx->subtask_id = i;
@@ -4570,10 +4570,15 @@ TEST_F(TabletParallelCompactionManagerTest, test_get_merged_txn_log_range_split)
         op->add_input_rowsets(1);
         op->add_input_rowsets(2);
         op->set_compact_version(version);
-        op->mutable_output_rowset()->set_num_rows(100 * (i + 1));
-        op->mutable_output_rowset()->set_data_size(1000 * (i + 1));
-        op->mutable_output_rowset()->add_segments(fmt::format("range_seg_{}.dat", i));
-        op->mutable_output_rowset()->add_segment_size(1000 * (i + 1));
+        auto* out = op->mutable_output_rowset();
+        out->set_num_rows(100 * (i + 1));
+        out->set_data_size(1000 * (i + 1));
+        out->add_segments(fmt::format("range_seg_{}.dat", i));
+        out->add_segment_size(1000 * (i + 1));
+        // Each subtask assigns segment_idx=0 independently; merge must renumber them.
+        auto* sm = out->add_segment_metas();
+        sm->set_segment_idx(0);
+        sm->set_num_rows(100 * (i + 1));
 
         {
             std::lock_guard<std::mutex> lock(state->mutex);
@@ -4598,11 +4603,19 @@ TEST_F(TabletParallelCompactionManagerTest, test_get_merged_txn_log_range_split)
 
     const auto& merged = op_parallel.subtask_compactions(0);
     EXPECT_EQ(3, merged.input_rowsets_size());
-    EXPECT_TRUE(merged.has_output_rowset());
+    ASSERT_TRUE(merged.has_output_rowset());
     EXPECT_EQ(600, merged.output_rowset().num_rows());    // 100+200+300
     EXPECT_EQ(6000, merged.output_rowset().data_size());   // 1000+2000+3000
     EXPECT_EQ(3, merged.output_rowset().segments_size());
     EXPECT_FALSE(merged.output_rowset().overlapped());
+    // next_compaction_offset must NOT be set for non-overlapped rowsets (proto contract).
+    EXPECT_FALSE(merged.output_rowset().has_next_compaction_offset());
+    // segment_idx must be renumbered sequentially: 0, 1, 2 (not 0, 0, 0).
+    ASSERT_EQ(3, merged.output_rowset().segment_metas_size());
+    for (int i = 0; i < 3; i++) {
+        EXPECT_EQ(static_cast<uint32_t>(i), merged.output_rowset().segment_metas(i).segment_idx())
+                << "segment_metas[" << i << "].segment_idx should be " << i;
+    }
 
     EXPECT_EQ(3, op_parallel.success_subtask_ids_size());
 


### PR DESCRIPTION
Issue 1: Add FRIEND_TEST declarations for private methods accessed by unit tests (_can_use_range_split, _collect_segment_key_bounds, _variant_tuple_to_olap_tuple, _create_range_split_groups). Without these declarations the tests fail to compile.

Issue 2: next_compaction_offset must only be set > 0 when overlapped=true per the RowsetMetadataPB proto contract. The range-split merge path was incorrectly setting it to segments_size() on a non-overlapped output rowset. Replace with clear_next_compaction_offset() so the field is left unset.

Issue 3: When merging segment_metas from multiple range-split (and large rowset split) subtasks, each subtask independently numbers its segments starting from segment_idx=0. Directly copying the metas produces duplicate segment_idx values in the merged rowset, causing RSSID collisions (rowset_id + segment_idx) in PK tables. Renumber segment_idx sequentially across subtasks during merge. Also update the existing range-split merge test to include segment_metas and assert correct segment_idx values and the absence of next_compaction_offset.

https://claude.ai/code/session_01CjskRZr29pm7ML1gZiuAN4

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
