### PR TITLE
Fix off-by-one in range-to-group assignment in tablet split

### DIFF
--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -239,7 +239,7 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
         size_t boundary_idx = 0;
         for (const auto* range : candidate_ranges) {
             while (boundary_idx < result.boundaries.size() &&
-                   range->max.compare(result.boundaries[boundary_idx]) >= 0) {
+                   range->max.compare(result.boundaries[boundary_idx]) > 0) {
                 boundary_idx++;
             }
             int32_t group_idx = std::min(static_cast<int32_t>(boundary_idx), num_splits - 1);


### PR DESCRIPTION
In calculate_range_split_boundaries Step 5, the comparison used >= when assigning ranges to split groups, which caused a range whose max key exactly equaled a boundary to advance past that boundary. This placed the range in the wrong (next) group, leaving the first group with 0 rows and 0 data_size.

Change the comparison from >= to > so that a range whose max equals a boundary stays in the current group.

https://claude.ai/code/session_01QCiNsGEd9yXUFu2j6kY36j

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
