### PR TITLE
Address review feedback for explicit transaction state handling

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -896,7 +896,7 @@ public class ConnectContext {
         // Clean up explicit transaction state to prevent memory leak in explicitTxnStateMap
         if (txnId != 0) {
             try {
-                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                globalStateMgr.getGlobalTransactionMgr()
                         .clearExplicitTxnState(txnId);
             } catch (Exception e) {
                 // Ignore exceptions during cleanup to avoid masking the original close reason

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -696,11 +696,12 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         for (DatabaseTransactionMgr dbTransactionMgr : dbIdToDatabaseTransactionMgrs.values()) {
             dbTransactionMgr.abortTimeoutTxns(currentMillis);
         }
-        // Clean up timed-out explicit transaction states that may have been orphaned
-        // (e.g., BEGIN executed but no DML followed, so no DatabaseTransactionMgr entry exists)
+        // Clean up orphaned explicit transaction states:
+        // 1. txnState == null: orphaned entry (e.g., state lost after FE leader switch)
+        // 2. txnState != null && isTimeout: BEGIN executed but no DML followed, timed out
         explicitTxnStateMap.entrySet().removeIf(entry -> {
             TransactionState txnState = entry.getValue().getTransactionState();
-            return txnState != null && txnState.isTimeout(currentMillis);
+            return txnState == null || txnState.isTimeout(currentMillis);
         });
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -103,6 +103,10 @@ public class TransactionStmtExecutor {
             ExplicitTxnState explicitTxnState = globalTransactionMgr.getExplicitTxnState(context.getTxnId());
             if (explicitTxnState == null || explicitTxnState.getTransactionState() == null) {
                 // Transaction state was lost (e.g., FE leader switch), reset and start fresh
+                if (explicitTxnState != null) {
+                    // Clear stale explicit transaction state to avoid leaving an orphaned entry
+                    globalTransactionMgr.clearExplicitTxnState(context.getTxnId());
+                }
                 context.setTxnId(0);
             } else {
                 String existingLabel = explicitTxnState.getTransactionState().getLabel();

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -647,4 +647,57 @@ public class ExplicitTxnTest {
         // Verify the timed-out state was cleaned up
         Assertions.assertNull(globalTransactionMgr.getExplicitTxnState(transactionId));
     }
+
+    @Test
+    public void testAbortTimeoutTxnsCleanupOrphanedNullState() {
+        // Test that abortTimeoutTxns() also cleans up entries where transactionState is null
+        // (orphaned entries from lost state, e.g., after FE leader switch)
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+
+        long orphanTxnId = globalTransactionMgr.getTransactionIDGenerator().getNextTransactionId();
+        ExplicitTxnState orphanState = new ExplicitTxnState();
+        // transactionState is null by default - simulates orphaned entry
+        globalTransactionMgr.addTransactionState(orphanTxnId, orphanState);
+
+        Assertions.assertNotNull(globalTransactionMgr.getExplicitTxnState(orphanTxnId));
+
+        // Run timeout cleanup
+        globalTransactionMgr.abortTimeoutTxns();
+
+        // Verify the orphaned null-state entry was cleaned up
+        Assertions.assertNull(globalTransactionMgr.getExplicitTxnState(orphanTxnId));
+    }
+
+    @Test
+    public void testBeginWithStaleExplicitTxnStateClearsEntry() {
+        // Test that beginStmt clears the stale map entry when explicitTxnState exists
+        // but transactionState is null
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+
+        TUniqueId queryId = new TUniqueId(960, 961);
+        context.setExecutionId(queryId);
+
+        // Add a stale entry with null transactionState
+        long staleTxnId = globalTransactionMgr.getTransactionIDGenerator().getNextTransactionId();
+        ExplicitTxnState staleState = new ExplicitTxnState();
+        globalTransactionMgr.addTransactionState(staleTxnId, staleState);
+        context.setTxnId(staleTxnId);
+
+        // beginStmt should detect the lost state, clean up stale entry, and start fresh
+        TransactionStmtExecutor.beginStmt(context, new BeginStmt(NodePosition.ZERO, "stale_cleanup_label"));
+
+        // Stale entry should be removed from the map
+        Assertions.assertNull(globalTransactionMgr.getExplicitTxnState(staleTxnId));
+        // A new transaction should have been started
+        Assertions.assertNotEquals(0, context.getTxnId());
+        Assertions.assertNotEquals(staleTxnId, context.getTxnId());
+        Assertions.assertFalse(context.getState().isError());
+
+        // Cleanup
+        globalTransactionMgr.clearExplicitTxnState(context.getTxnId());
+        context.setTxnId(0);
+    }
 }


### PR DESCRIPTION
1. ConnectContext.cleanup(): Use instance globalStateMgr instead of static GlobalStateMgr.getCurrentState() to stay consistent with the session's state manager reference.

2. GlobalTransactionMgr.abortTimeoutTxns(): Also clean up entries where transactionState is null (orphaned entries from FE leader switch), not just timed-out entries with non-null state.

3. TransactionStmtExecutor.beginStmt(): Clear stale map entry when explicitTxnState exists but transactionState is null, to avoid leaving orphaned entries in explicitTxnStateMap.

4. Add tests for orphaned null-state cleanup and stale entry cleanup in beginStmt.

https://claude.ai/code/session_018fWjJ8CEJQ3bwN8oMjZzmb

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
