### PR TITLE
[BugFix] Fix P1 review issues: fail-fast on inconsistent bundle_file_…

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -17,6 +17,8 @@
 #include <algorithm>
 #include <memory>
 
+#include <fmt/format.h>
+
 #include "base/coding.h"
 #include "base/container/raw_container.h"
 #include "base/debug/trace.h"
@@ -916,9 +918,9 @@ void MetaFileBuilder::add_rowset(const RowsetMetadataPB& rowset_pb, const std::m
     _pending_rowset_data.assigned_segment_idx += get_rowset_id_step(rowset_pb);
 }
 
-void MetaFileBuilder::set_final_rowset() {
+Status MetaFileBuilder::set_final_rowset() {
     if (_pending_rowset_data.rowset_pb.segments_size() == 0 && _pending_rowset_data.dels.empty()) {
-        return; // Nothing to do
+        return Status::OK(); // Nothing to do
     }
 
     auto rowset = _tablet_meta->add_rowsets();
@@ -932,12 +934,13 @@ void MetaFileBuilder::set_final_rowset() {
 
     // Validate bundle_file_offsets 1:1 correspondence with segments before applying replace_segments.
     // During batch apply of multiple opwrites, some may have offsets and some may not, leading to
-    // inconsistent counts. Drop offsets if they don't match to maintain invariant.
+    // inconsistent counts. This is an error that must abort publish to prevent data corruption —
+    // silently clearing offsets would leave bundled segment paths without positional info.
     if (rowset->bundle_file_offsets_size() > 0 && rowset->bundle_file_offsets_size() != rowset->segments_size()) {
-        LOG(WARNING) << "bundle_file_offsets count mismatch in merged rowset for tablet " << _tablet.id()
-                     << ": offsets=" << rowset->bundle_file_offsets_size() << " segments=" << rowset->segments_size()
-                     << ", clearing offsets";
-        rowset->clear_bundle_file_offsets();
+        return Status::InternalError(
+                fmt::format("bundle_file_offsets count mismatch in merged rowset for tablet {}: "
+                            "offsets={} segments={}. Aborting publish to prevent data corruption.",
+                            _tablet.id(), rowset->bundle_file_offsets_size(), rowset->segments_size()));
     }
 
     // Apply replace_segments
@@ -987,6 +990,8 @@ void MetaFileBuilder::set_final_rowset() {
 
     // Clear pending cache
     _pending_rowset_data = PendingRowsetData{};
+
+    return Status::OK();
 }
 
 void MetaFileBuilder::batch_apply_opwrite(const TxnLogPB_OpWrite& op_write,

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -68,7 +68,7 @@ public:
     void add_rowset(const RowsetMetadataPB& rowset_pb, const std::map<int, FileInfo>& replace_segments,
                     const std::vector<FileMetaPB>& orphan_files, const std::vector<std::string>& dels,
                     const std::vector<std::string>& del_encryption_metas);
-    void set_final_rowset();
+    Status set_final_rowset();
 
     // finalize will generate and sync final meta state to storage.
     // |txn_id| the maximum applied transaction ID, used to construct the delvec file name, and

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -303,7 +303,7 @@ public:
                 }
             }
         }
-        _builder.set_final_rowset();
+        RETURN_IF_ERROR(_builder.set_final_rowset());
 
         return Status::OK();
     }
@@ -773,7 +773,6 @@ public:
         std::vector<int64_t> all_bundle_file_offsets;
         bool has_bundle_offsets = false;
         bool has_segments_without_bundle_offsets = false;
-        bool mixed_bundle_offsets = false;
         uint32_t assigned_segment_idx = 0;
 
         // Traverse all transaction logs and collect op_write information
@@ -836,10 +835,11 @@ public:
                     // Each TxnLog's rowset either has all offsets (bundled) or none (standalone).
                     if (rowset.bundle_file_offsets_size() > 0) {
                         if (rowset.bundle_file_offsets_size() != rowset.segments_size()) {
-                            LOG(WARNING) << "bundle_file_offsets size mismatch in txn log for tablet " << _tablet.id()
-                                         << ": offsets=" << rowset.bundle_file_offsets_size()
-                                         << " segments=" << rowset.segments_size();
-                            mixed_bundle_offsets = true;
+                            return Status::InternalError(
+                                    fmt::format("bundle_file_offsets size mismatch in txn log for tablet {}: "
+                                                "offsets={} segments={}",
+                                                _tablet.id(), rowset.bundle_file_offsets_size(),
+                                                rowset.segments_size()));
                         } else {
                             has_bundle_offsets = true;
                             all_bundle_file_offsets.reserve(all_bundle_file_offsets.size() +
@@ -892,24 +892,24 @@ public:
             merged_rowset->add_segment_metas()->CopyFrom(segment_meta);
         }
 
-        // Detect inconsistent bundling: some TxnLogs have offsets, others don't (regardless of order).
+        // Validate bundle file offsets consistency across all TxnLogs.
+        // All TxnLogs must consistently either have or lack bundle_file_offsets.
+        // Mixing bundled and non-bundled rowsets is an error because downstream readers
+        // require offsets to locate segments within bundle files. Silently dropping offsets
+        // would leave bundled segment paths without positional info, causing data corruption.
         if (has_bundle_offsets && has_segments_without_bundle_offsets) {
-            LOG(WARNING) << "Inconsistent bundle_file_offsets across txn logs for tablet " << _tablet.id()
-                         << ": some logs have offsets, some don't";
-            mixed_bundle_offsets = true;
+            return Status::InternalError(
+                    fmt::format("Inconsistent bundle_file_offsets across txn logs for tablet {}: "
+                                "some logs have offsets, some don't. Cannot safely merge rowsets.",
+                                _tablet.id()));
         }
 
         // Set bundle file offsets if all TxnLogs consistently have them.
-        // When !mixed_bundle_offsets, every TxnLog with segments has matching offsets,
-        // so the total offsets count must equal the total segments count.
-        if (has_bundle_offsets && !mixed_bundle_offsets) {
+        if (has_bundle_offsets) {
             DCHECK_EQ(all_bundle_file_offsets.size(), static_cast<size_t>(merged_rowset->segments_size()));
             for (int64_t offset : all_bundle_file_offsets) {
                 merged_rowset->add_bundle_file_offsets(offset);
             }
-        } else if (mixed_bundle_offsets) {
-            LOG(WARNING) << "Dropping bundle_file_offsets for merged rowset of tablet " << _tablet.id()
-                         << " due to inconsistent bundling across txn logs";
         }
 
         // Set rowset ID and update next_rowset_id

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -859,7 +859,7 @@ TEST_F(MetaFileTest, test_batch_apply_opwrite_set_final_rowset_basic) {
     ASSERT_TRUE(builder.update_num_del_stat(segid_to_add_dels).ok());
 
     // Seal pending rowset
-    builder.set_final_rowset();
+    ASSERT_TRUE(builder.set_final_rowset().ok());
     ASSERT_EQ(1, metadata->rowsets_size());
     const auto& final_rowset = metadata->rowsets(0);
     EXPECT_EQ(110, final_rowset.id());
@@ -910,7 +910,7 @@ TEST_F(MetaFileTest, test_batch_apply_opwrite_merge_dels) {
     op_write2.add_dels("d3.del");
     builder.batch_apply_opwrite(op_write2, {}, {});
 
-    builder.set_final_rowset();
+    ASSERT_TRUE(builder.set_final_rowset().ok());
     ASSERT_EQ(1, metadata->rowsets_size());
     const auto& final_rowset = metadata->rowsets(0);
     EXPECT_EQ(500, final_rowset.id());
@@ -965,7 +965,7 @@ TEST_F(MetaFileTest, test_batch_apply_opwrite_mixed_segment_meta_presence) {
     op_write2.add_dels("d2.del");
     builder.batch_apply_opwrite(op_write2, {}, {});
 
-    builder.set_final_rowset();
+    ASSERT_TRUE(builder.set_final_rowset().ok());
     ASSERT_EQ(1, metadata->rowsets_size());
     const auto& final_rowset = metadata->rowsets(0);
     ASSERT_EQ(3, final_rowset.segments_size());

--- a/be/test/storage/lake/txn_log_applier_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_test.cpp
@@ -428,8 +428,9 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeNoBundleOffsets) {
     EXPECT_EQ(0, rs.bundle_file_offsets_size());
 }
 
-// Test that mixed bundle_file_offsets (some TxnLogs with, some without) drops all offsets defensively.
-TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeMixedBundleOffsets) {
+// Test that mixed bundle_file_offsets (some TxnLogs with, some without) returns error to prevent
+// data corruption — silently dropping offsets would leave bundled segment paths unresolvable.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeMixedBundleOffsetsReturnsError) {
     Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 10012);
     auto meta = build_non_pk_metadata(10012);
     auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
@@ -441,18 +442,13 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeMixedBundleOffsets) {
     logs.push_back(make_op_write_log(10012, 11, 7, 140, {"seg_b"}));
 
     Status st = applier->apply(logs);
-    EXPECT_TRUE(st.ok()) << st.to_string();
-
-    ASSERT_EQ(1, meta->rowsets_size());
-    const auto& rs = meta->rowsets(0);
-    EXPECT_EQ(2, rs.segments_size());
-    // Mixed offsets should result in no offsets on the merged rowset
-    EXPECT_EQ(0, rs.bundle_file_offsets_size());
+    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
+    EXPECT_NE(std::string::npos, st.to_string().find("Inconsistent bundle_file_offsets"));
 }
 
 // Test reverse order: first TxnLog has no offsets, second has offsets.
-// This must also be detected as mixed and drop all offsets.
-TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeMixedBundleOffsetsReverse) {
+// This must also be detected as inconsistent and return error.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeMixedBundleOffsetsReverseReturnsError) {
     Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 10013);
     auto meta = build_non_pk_metadata(10013);
     auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
@@ -464,13 +460,23 @@ TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeMixedBundleOffsetsReverse) {
     logs.push_back(make_op_write_log_with_bundle(10013, 11, 7, 140, {"seg_c"}, {0}));
 
     Status st = applier->apply(logs);
-    EXPECT_TRUE(st.ok()) << st.to_string();
+    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
+    EXPECT_NE(std::string::npos, st.to_string().find("Inconsistent bundle_file_offsets"));
+}
 
-    ASSERT_EQ(1, meta->rowsets_size());
-    const auto& rs = meta->rowsets(0);
-    EXPECT_EQ(3, rs.segments_size());
-    // Mixed offsets (reverse order) should also result in no offsets
-    EXPECT_EQ(0, rs.bundle_file_offsets_size());
+// Test that a single TxnLog with mismatched offset/segment count returns error.
+TEST(TxnLogApplierBatchTest, NonPrimaryKeyBatchMergeBundleOffsetSizeMismatchReturnsError) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 10014);
+    auto meta = build_non_pk_metadata(10014);
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    TxnLogVector logs;
+    // 2 segments but only 1 offset → mismatch within single TxnLog
+    logs.push_back(make_op_write_log_with_bundle(10014, 10, 5, 100, {"seg_a", "seg_b"}, {0}));
+
+    Status st = applier->apply(logs);
+    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
+    EXPECT_NE(std::string::npos, st.to_string().find("mismatch"));
 }
 
 TEST(TxnLogApplierBatchTest, NonPrimaryKeyReplicationWithoutTabletMetaSparseSegmentIdStep) {


### PR DESCRIPTION
…offsets

Address two P1 review concerns where mixed or mismatched bundle_file_offsets were silently dropped during publish, potentially causing data corruption.

P1 #1 (txn_log_applier.cpp): When multi-statement transactions mix bundled and non-bundled rowsets, the code logged a warning and dropped all offsets while keeping bundled segment paths. Downstream readers cannot locate segment positions without offsets, causing silent data corruption.

P1 #2 (meta_file.cpp): PK merged rowsets with offset/segment count mismatches had their offsets silently cleared, orphaning bundled segment references.

Fix: Return Status::InternalError to reject the publish operation instead of silently clearing offsets. This ensures inconsistencies are surfaced immediately rather than causing hard-to-diagnose data corruption at read time.

Changes:
- txn_log_applier.cpp: Return InternalError on offset/segment mismatch within a single TxnLog and on inconsistent bundling across TxnLogs. Remove the mixed_bundle_offsets flag and defensive-drop codepath.
- meta_file.h/cpp: Change set_final_rowset() from void to Status. Return InternalError on offset/segment count mismatch instead of clearing offsets.
- Update all call sites to check set_final_rowset() return status.
- Update mixed-bundling tests to expect InternalError instead of silent success.
- Add new test for single-TxnLog offset/segment count mismatch.

https://claude.ai/code/session_01MpEZ1RQRWQUV4JjNFUheyG

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
