### PR TITLE
Fix greedy boundary placement in tablet split algorithm

### DIFF
--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -191,7 +191,7 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
         size_t remaining_non_empty_after = (i + 1 < candidate_ranges.size()) ? remaining_non_empty_at[i + 1] : 0;
 
         if (!is_last_range && remaining_splits > 0 && is_non_empty &&
-            (accumulated >= actual_target || remaining_non_empty_after < static_cast<size_t>(remaining_splits))) {
+            (accumulated >= actual_target || remaining_non_empty_after <= static_cast<size_t>(remaining_splits))) {
             // Advance boundary across trailing empty ranges to maximize natural gaps.
             const VariantTuple* boundary = &range->max;
             for (size_t j = i + 1; j < candidate_ranges.size(); j++) {


### PR DESCRIPTION
The condition for forcing a boundary when running low on non-empty ranges used strict less-than (<), which failed when the count of remaining non-empty ranges exactly equaled the remaining splits needed. This caused the algorithm to skip the current range, reach the last range (where boundaries cannot be placed), and produce fewer splits than requested.

Change the check from < to <= so that a boundary is placed when the number of remaining non-empty ranges equals the remaining splits, ensuring all requested splits are produced.

Fixes LakeServiceTest.test_publish_splitting_tablet and LakeServiceTest.test_splitting_tablet_split_count_three_with_final_acc_stats.

https://claude.ai/code/session_01WS2gBgv2mMYyhnuFRXriqg

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
