### PR TITLE
Fix get_merged_txn_log to return success when subtasks skipped due to…

### DIFF
--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1117,10 +1117,12 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
             }
 
             // Collect successful subtask IDs, excluding subtasks from failed large rowset groups
+            int32_t actual_failure_count = 0;
             for (const auto& ctx : state->completed_subtasks) {
                 if (!ctx->status.ok()) {
                     LOG(WARNING) << "Parallel compaction: skipping failed subtask " << ctx->subtask_id << " for tablet "
                                  << tablet_id << ", txn_id=" << txn_id << ", status=" << ctx->status;
+                    actual_failure_count++;
                     continue;
                 }
 
@@ -1137,8 +1139,10 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
                 success_subtask_ids.push_back(ctx->subtask_id);
             }
 
-            // If no successful subtasks, return error
-            if (success_subtask_ids.empty()) {
+            // If no successful subtasks, return error only when there were actual failures.
+            // If subtasks were skipped solely due to incomplete large rowset groups (all individual
+            // statuses were ok), treat it as a valid no-op compaction and return success.
+            if (success_subtask_ids.empty() && actual_failure_count > 0) {
                 return Status::InternalError(strings::Substitute(
                         "All subtasks failed for parallel compaction: tablet_id=$0, txn_id=$1, total_subtasks=$2",
                         tablet_id, txn_id, state->completed_subtasks.size()));


### PR DESCRIPTION
… incomplete large rowset groups

When all subtasks belong to an incomplete large rowset split group (expected N subtasks but fewer were created), they are correctly skipped to prevent data loss. However, the previous code incorrectly returned an InternalError when success_subtask_ids was empty, even if all individual subtask statuses were ok.

Only return an error when there were actual subtask failures (status not ok). When subtasks are skipped solely due to incomplete large rowset groups, treat it as a valid no-op compaction and return success with empty success_subtask_ids.

Fixes TabletParallelCompactionManagerTest.test_large_rowset_split_group_incomplete

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
