### PR TITLE
Fix incomplete large rowset split not detected as compaction failure

### DIFF
--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1139,10 +1139,16 @@ StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t t
                 success_subtask_ids.push_back(ctx->subtask_id);
             }
 
-            // If no successful subtasks, return error only when there were actual failures.
-            // If subtasks were skipped solely due to incomplete large rowset groups (all individual
-            // statuses were ok), treat it as a valid no-op compaction and return success.
-            if (success_subtask_ids.empty() && actual_failure_count > 0) {
+            // If no successful subtasks remain after filtering, return error.
+            // This covers two cases:
+            //   1. actual_failure_count > 0: some subtasks actually failed.
+            //   2. !failed_large_rowset_ids.empty(): all subtasks were skipped because they
+            //      belonged to incomplete large rowset split groups (the split was not fully
+            //      created, e.g. due to acquire_token() failures). In this case, continuing
+            //      would produce a txn_log that silently drops the unprocessed segments,
+            //      causing data loss. Returning an error prevents the txn_log from being
+            //      added to the response so the compaction fails entirely.
+            if (success_subtask_ids.empty() && (actual_failure_count > 0 || !failed_large_rowset_ids.empty())) {
                 return Status::InternalError(strings::Substitute(
                         "All subtasks failed for parallel compaction: tablet_id=$0, txn_id=$1, total_subtasks=$2",
                         tablet_id, txn_id, state->completed_subtasks.size()));


### PR DESCRIPTION
When a large rowset split group is incomplete (expected N subtasks but only M < N were created, e.g. due to acquire_token() failures), all subtasks in the group are correctly skipped. However, the previous condition at success_subtask_ids.empty() check only returned an error when there were actual per-subtask failures (actual_failure_count > 0). When all individual subtask statuses were OK but the group was incomplete, the code fell through and produced an essentially empty txn_log that was added to the response, silently ignoring the unprocessed segments and risking data loss.

Fix: also return InternalError when success_subtask_ids is empty due to failed_large_rowset_ids being non-empty (incomplete split groups), so that the merged_context->txn_log is never set and no txn_log is added to the CompactResponse.

Fixes: TabletParallelCompactionManagerLargeRowsetTest.test_incomplete_large_rowset_split_detected_as_failed
Fixes: TabletParallelCompactionManagerTest.test_get_merged_txn_log_large_rowset_split_incomplete

https://claude.ai/code/session_016WLozSQX5BJ8vRFuKRPAq7

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
