### PR TITLE
Fix test_large_rowset_split_group_incomplete to expect error status

### DIFF
--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -5122,12 +5122,11 @@ TEST_F(TabletParallelCompactionManagerTest, test_large_rowset_split_group_incomp
     }
 
     auto result = _manager->get_merged_txn_log(tablet_id, txn_id);
-    ASSERT_TRUE(result.ok()) << result.status();
-
-    const auto& op_parallel = result.value().op_parallel_compaction();
-    // Both subtasks should be skipped because the group is incomplete
-    EXPECT_EQ(0, op_parallel.success_subtask_ids_size())
-            << "All subtasks from incomplete large rowset group should be skipped";
+    // When all subtasks belong to an incomplete large rowset group and none succeed,
+    // get_merged_txn_log returns an error to prevent data loss from silently dropping
+    // unprocessed segments.
+    ASSERT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().is_internal_error());
 
     _manager->cleanup_tablet(tablet_id, txn_id);
 }


### PR DESCRIPTION
The test expected get_merged_txn_log to return OK with 0 success subtasks, but the source code intentionally returns an InternalError when all subtasks are skipped due to incomplete large rowset split groups, to prevent data loss from silently dropping unprocessed segments.

https://claude.ai/code/session_01VJ9G5233FH1eDGEub6F2up

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
