### PR TITLE
Fix compilation errors in tablet_parallel_compaction_manager_test

### DIFF
--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -6352,7 +6352,7 @@ TEST_F(TabletParallelCompactionManagerTest, test_submit_range_split_groups_state
 // Tests for _variant_tuple_to_olap_tuple with null value
 // =============================================================================
 
-TEST_F(TabletParallelCompactionManagerTest, test_variant_tuple_to_olap_tuple_null_value) {
+TEST_F(TabletParallelCompactionManagerTest, test_variant_tuple_to_olap_tuple_null_value_single) {
     // Create a VariantTuple with a null datum
     VariantTuple vt;
     auto type_info = get_type_info(TYPE_INT);
@@ -6420,8 +6420,8 @@ TEST_F(TabletParallelCompactionManagerTest, test_range_split_merge_with_lcrm_fil
     sst0->set_name("sst_0.sst");
     // Add SST range
     auto* sst_range0 = op0->add_sst_ranges();
-    sst_range0->set_start(0);
-    sst_range0->set_end(100);
+    sst_range0->set_start_key("0");
+    sst_range0->set_end_key("100");
     // Add LCRM file
     auto* lcrm0 = op0->mutable_lcrm_file();
     lcrm0->set_name("lcrm_0.dat");


### PR DESCRIPTION
- Rename duplicate test `test_variant_tuple_to_olap_tuple_null_value` at line 6355 to `test_variant_tuple_to_olap_tuple_null_value_single` to resolve redefinition error (original at line 5181)
- Fix `set_start`/`set_end` calls to `set_start_key`/`set_end_key` to match the PersistentIndexSstableRangePB proto definition (bytes fields, not int)

https://claude.ai/code/session_01ESQRHS4c4gtNUWnNk8Wqe8

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
