### PR TITLE
Fix LCRM test failures by creating actual LCRM files on disk

### DIFF
--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -6013,6 +6013,19 @@ TEST_F(TabletParallelCompactionManagerTest, test_large_rowset_split_merge_with_l
 
     _manager->register_tablet_state_for_test(tablet_id, txn_id, state);
 
+    // Create LCRM files on disk so _merge_subtask_lcrm_files can read them
+    for (int i = 0; i < 2; i++) {
+        std::string lcrm_name = fmt::format("lcrm_{}.dat", i);
+        std::string lcrm_path = _tablet_mgr->lcrm_location(tablet_id, lcrm_name);
+        std::string dir = std::filesystem::path(lcrm_path).parent_path().string();
+        CHECK_OK(fs::create_directories(dir));
+        RowsMapperBuilder builder(lcrm_path);
+        size_t num_rows = (i == 0) ? 100 : 200;
+        std::vector<uint64_t> dummy_rows(num_rows, static_cast<uint64_t>(i));
+        CHECK_OK(builder.append(dummy_rows));
+        CHECK_OK(builder.finalize());
+    }
+
     // Complete subtask 0 with LCRM file
     auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
     ctx0->subtask_id = 0;
@@ -6401,6 +6414,19 @@ TEST_F(TabletParallelCompactionManagerTest, test_range_split_merge_with_lcrm_fil
     }
 
     _manager->register_tablet_state_for_test(tablet_id, txn_id, state);
+
+    // Create LCRM files on disk so _merge_subtask_lcrm_files can read them
+    for (int i = 0; i < 2; i++) {
+        std::string lcrm_name = fmt::format("lcrm_{}.dat", i);
+        std::string lcrm_path = _tablet_mgr->lcrm_location(tablet_id, lcrm_name);
+        std::string dir = std::filesystem::path(lcrm_path).parent_path().string();
+        CHECK_OK(fs::create_directories(dir));
+        RowsMapperBuilder builder(lcrm_path);
+        size_t num_rows = (i == 0) ? 100 : 200;
+        std::vector<uint64_t> dummy_rows(num_rows, static_cast<uint64_t>(i));
+        CHECK_OK(builder.append(dummy_rows));
+        CHECK_OK(builder.finalize());
+    }
 
     // Complete subtask 0 with SST files and LCRM file
     auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);


### PR DESCRIPTION
The tests test_large_rowset_split_merge_with_lcrm and test_range_split_merge_with_lcrm_files were setting LCRM file metadata in protobuf but never creating the actual files on the filesystem. When _merge_subtask_lcrm_files runs and opens the files via RowsMapperIterator, the files don't exist, causing the merge to fail.

Add file creation blocks (using RowsMapperBuilder) before subtask completion, following the pattern from the working test test_get_merged_txn_log_range_split_with_lcrm.

https://claude.ai/code/session_01GLy5o3SHJ1SPkMA6rA1irW

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
