### PR TITLE
Preserve CompactionTaskStats in parallel compaction profile

### DIFF
--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1607,6 +1607,27 @@ Status TabletParallelCompactionManager::execute_sst_compaction_for_parallel(
     return Status::OK();
 }
 
+std::string TabletParallelCompactionManager::_merge_subtask_info_into_stats_json(const std::string& stats_json,
+                                                                                  int32_t subtask_id,
+                                                                                  size_t input_rowsets,
+                                                                                  int64_t input_bytes) {
+    auto subtask_fields =
+            fmt::format(R"("subtask_id":{},"input_rowsets":{},"input_bytes":{},"is_parallel_subtask":true)",
+                        subtask_id, input_rowsets, input_bytes);
+    if (stats_json.size() < 2 || stats_json.front() != '{' || stats_json.back() != '}') {
+        return fmt::format("{{{}}}", subtask_fields);
+    }
+    // stats_json looks like "{...}"; insert subtask fields before the trailing '}'.
+    // If the stats object is empty ("{}"), avoid emitting a leading comma.
+    std::string out = stats_json.substr(0, stats_json.size() - 1);
+    if (out.size() > 1) {
+        out.push_back(',');
+    }
+    out.append(subtask_fields);
+    out.push_back('}');
+    return out;
+}
+
 void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>* infos) {
     std::lock_guard<std::mutex> lock(_states_mutex);
     for (const auto& [state_key, state_ptr] : _tablet_states) {
@@ -1634,10 +1655,14 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
                 info.progress = 0;
             }
             info.status = Status::OK();
-            // Build profile with subtask-specific info
-            info.profile =
-                    fmt::format(R"({{"subtask_id":{},"input_rowsets":{},"input_bytes":{},"is_parallel_subtask":true}})",
-                                subtask_id, subtask_info.input_rowset_ids.size(), subtask_info.input_bytes);
+            // Build profile from stats and append subtask-specific info.
+            std::string stats_json;
+            if (subtask_info.context != nullptr && subtask_info.context->stats != nullptr) {
+                stats_json = subtask_info.context->stats->to_json_stats();
+            }
+            info.profile = _merge_subtask_info_into_stats_json(stats_json, subtask_id,
+                                                                subtask_info.input_rowset_ids.size(),
+                                                                subtask_info.input_bytes);
         }
 
         // Add completed subtasks that haven't been cleaned up yet

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1607,7 +1607,7 @@ Status TabletParallelCompactionManager::execute_sst_compaction_for_parallel(
     return Status::OK();
 }
 
-std::string TabletParallelCompactionManager::_merge_subtask_info_into_stats_json(const std::string& stats_json,
+std::string TabletParallelCompactionManager::merge_subtask_info_into_stats_json(const std::string& stats_json,
                                                                                   int32_t subtask_id,
                                                                                   size_t input_rowsets,
                                                                                   int64_t input_bytes) {
@@ -1660,7 +1660,7 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
             if (subtask_info.context != nullptr && subtask_info.context->stats != nullptr) {
                 stats_json = subtask_info.context->stats->to_json_stats();
             }
-            info.profile = _merge_subtask_info_into_stats_json(stats_json, subtask_id,
+            info.profile = merge_subtask_info_into_stats_json(stats_json, subtask_id,
                                                                 subtask_info.input_rowset_ids.size(),
                                                                 subtask_info.input_bytes);
         }

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1608,12 +1608,12 @@ Status TabletParallelCompactionManager::execute_sst_compaction_for_parallel(
 }
 
 std::string TabletParallelCompactionManager::merge_subtask_info_into_stats_json(const std::string& stats_json,
-                                                                                  int32_t subtask_id,
-                                                                                  size_t input_rowsets,
-                                                                                  int64_t input_bytes) {
+                                                                                int32_t subtask_id,
+                                                                                size_t input_rowsets,
+                                                                                int64_t input_bytes) {
     auto subtask_fields =
-            fmt::format(R"("subtask_id":{},"input_rowsets":{},"input_bytes":{},"is_parallel_subtask":true)",
-                        subtask_id, input_rowsets, input_bytes);
+            fmt::format(R"("subtask_id":{},"input_rowsets":{},"input_bytes":{},"is_parallel_subtask":true)", subtask_id,
+                        input_rowsets, input_bytes);
     if (stats_json.size() < 2 || stats_json.front() != '{' || stats_json.back() != '}') {
         return fmt::format("{{{}}}", subtask_fields);
     }
@@ -1660,9 +1660,8 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
             if (subtask_info.context != nullptr && subtask_info.context->stats != nullptr) {
                 stats_json = subtask_info.context->stats->to_json_stats();
             }
-            info.profile = merge_subtask_info_into_stats_json(stats_json, subtask_id,
-                                                                subtask_info.input_rowset_ids.size(),
-                                                                subtask_info.input_bytes);
+            info.profile = merge_subtask_info_into_stats_json(
+                    stats_json, subtask_id, subtask_info.input_rowset_ids.size(), subtask_info.input_bytes);
         }
 
         // Add completed subtasks that haven't been cleaned up yet

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -226,6 +226,11 @@ public:
     }
 
 private:
+    // Combine the stats JSON produced by CompactionTaskStats::to_json_stats() with
+    // subtask-specific fields used by information_schema.be_cloud_native_compactions.
+    static std::string _merge_subtask_info_into_stats_json(const std::string& stats_json, int32_t subtask_id,
+                                                            size_t input_rowsets, int64_t input_bytes);
+
     // Mark rowsets as being compacted
     void mark_rowsets_compacting(TabletParallelCompactionState* state, const std::vector<uint32_t>& rowset_ids);
 

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -225,12 +225,13 @@ public:
         _tablet_states[key] = std::move(state);
     }
 
-private:
     // Combine the stats JSON produced by CompactionTaskStats::to_json_stats() with
     // subtask-specific fields used by information_schema.be_cloud_native_compactions.
-    static std::string _merge_subtask_info_into_stats_json(const std::string& stats_json, int32_t subtask_id,
-                                                            size_t input_rowsets, int64_t input_bytes);
+    // Exposed for unit testing.
+    static std::string merge_subtask_info_into_stats_json(const std::string& stats_json, int32_t subtask_id,
+                                                          size_t input_rowsets, int64_t input_bytes);
 
+private:
     // Mark rowsets as being compacted
     void mark_rowsets_compacting(TabletParallelCompactionState* state, const std::vector<uint32_t>& rowset_ids);
 

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <future>
 
@@ -6982,6 +6983,110 @@ TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_range_spl
         _manager->execute_subtask_range_split(99999, 99999, 0, std::move(empty_rowsets), lower, upper, true, true, true,
                                               true, 1, false, [](bool) {});
     }
+}
+
+// Verify that merge_subtask_info_into_stats_json keeps the CompactionTaskStats
+// JSON object intact and appends the subtask-specific fields. This guards the
+// information_schema.be_cloud_native_compactions PROFILE column from regressing
+// to a subtask-only payload that drops to_json_stats() output.
+TEST(TabletParallelCompactionManagerProfileTest, merge_subtask_info_preserves_stats) {
+    std::string stats =
+            R"({"read_local_sec":1,"read_local_mb":2,"read_remote_sec":3,"read_remote_mb":4,)"
+            R"("read_remote_count":5,"read_local_count":6})";
+    std::string merged = TabletParallelCompactionManager::merge_subtask_info_into_stats_json(stats, /*subtask_id=*/2,
+                                                                                              /*input_rowsets=*/7,
+                                                                                              /*input_bytes=*/12345);
+
+    // All original stats keys must still be present.
+    EXPECT_NE(std::string::npos, merged.find(R"("read_local_sec":1)"));
+    EXPECT_NE(std::string::npos, merged.find(R"("read_local_mb":2)"));
+    EXPECT_NE(std::string::npos, merged.find(R"("read_remote_count":5)"));
+    EXPECT_NE(std::string::npos, merged.find(R"("read_local_count":6)"));
+
+    // Subtask-specific fields are appended.
+    EXPECT_NE(std::string::npos, merged.find(R"("subtask_id":2)"));
+    EXPECT_NE(std::string::npos, merged.find(R"("input_rowsets":7)"));
+    EXPECT_NE(std::string::npos, merged.find(R"("input_bytes":12345)"));
+    EXPECT_NE(std::string::npos, merged.find(R"("is_parallel_subtask":true)"));
+
+    // The result is a single JSON object.
+    EXPECT_EQ('{', merged.front());
+    EXPECT_EQ('}', merged.back());
+    // Subtask fields are inserted before the closing brace, so the original last
+    // stats key must come before "subtask_id" and there must be no "}{" join.
+    EXPECT_LT(merged.find(R"("read_local_count":6)"), merged.find(R"("subtask_id":2)"));
+    EXPECT_EQ(std::string::npos, merged.find("}{"));
+    // Exactly one closing brace.
+    EXPECT_EQ(1u, std::count(merged.begin(), merged.end(), '}'));
+}
+
+TEST(TabletParallelCompactionManagerProfileTest, merge_subtask_info_with_empty_stats_object) {
+    // to_json_stats() always returns a JSON object; emulate the degenerate "{}" case
+    // and make sure we don't emit a leading comma like {,"subtask_id":...}.
+    std::string merged = TabletParallelCompactionManager::merge_subtask_info_into_stats_json("{}", /*subtask_id=*/0,
+                                                                                              /*input_rowsets=*/1,
+                                                                                              /*input_bytes=*/2);
+    EXPECT_EQ(R"({"subtask_id":0,"input_rowsets":1,"input_bytes":2,"is_parallel_subtask":true})", merged);
+}
+
+TEST(TabletParallelCompactionManagerProfileTest, merge_subtask_info_with_missing_stats) {
+    // If the stats JSON is missing or malformed, fall back to a subtask-only object
+    // rather than producing invalid JSON.
+    std::string from_empty = TabletParallelCompactionManager::merge_subtask_info_into_stats_json(
+            "", /*subtask_id=*/3, /*input_rowsets=*/4, /*input_bytes=*/5);
+    EXPECT_EQ(R"({"subtask_id":3,"input_rowsets":4,"input_bytes":5,"is_parallel_subtask":true})", from_empty);
+
+    std::string from_garbage = TabletParallelCompactionManager::merge_subtask_info_into_stats_json(
+            "not-json", /*subtask_id=*/9, /*input_rowsets=*/0, /*input_bytes=*/0);
+    EXPECT_EQ(R"({"subtask_id":9,"input_rowsets":0,"input_bytes":0,"is_parallel_subtask":true})", from_garbage);
+}
+
+// End-to-end check on list_tasks: a running subtask whose context has populated
+// CompactionTaskStats must surface both the to_json_stats() payload and the
+// subtask metadata in CompactionTaskInfo::profile.
+TEST_F(TabletParallelCompactionManagerTest, list_tasks_running_profile_contains_stats_and_subtask_info) {
+    int64_t tablet_id = 90001;
+    int64_t txn_id = 90001;
+    int64_t version = 1;
+
+    auto state = std::make_shared<TabletParallelCompactionState>();
+    state->tablet_id = tablet_id;
+    state->txn_id = txn_id;
+    state->version = version;
+    state->total_subtasks_created = 1;
+
+    auto ctx = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx->subtask_id = 7;
+    // Populate stats so to_json_stats() emits non-default values we can grep for.
+    ctx->stats->io_bytes_read_remote = static_cast<int64_t>(100) * 1048576; // 100 MB
+    ctx->stats->read_segment_count = 42;
+
+    SubtaskInfo subtask_info;
+    subtask_info.subtask_id = 7;
+    subtask_info.input_rowset_ids = {1, 2, 3};
+    subtask_info.input_bytes = 999;
+    subtask_info.context = ctx.get();
+    state->running_subtasks.emplace(7, std::move(subtask_info));
+
+    _manager->register_tablet_state_for_test(tablet_id, txn_id, state);
+
+    std::vector<CompactionTaskInfo> infos;
+    _manager->list_tasks(&infos);
+    ASSERT_EQ(1u, infos.size());
+
+    const auto& profile = infos[0].profile;
+    // Stats from to_json_stats() are preserved.
+    EXPECT_NE(std::string::npos, profile.find(R"("read_remote_mb":100)")) << profile;
+    EXPECT_NE(std::string::npos, profile.find(R"("read_segment_count":42)")) << profile;
+    // Subtask-specific fields are also present.
+    EXPECT_NE(std::string::npos, profile.find(R"("subtask_id":7)")) << profile;
+    EXPECT_NE(std::string::npos, profile.find(R"("input_rowsets":3)")) << profile;
+    EXPECT_NE(std::string::npos, profile.find(R"("input_bytes":999)")) << profile;
+    EXPECT_NE(std::string::npos, profile.find(R"("is_parallel_subtask":true)")) << profile;
+
+    // Clean up: remove the registered state without going through the executor.
+    state->running_subtasks.clear();
+    _manager->cleanup_tablet(tablet_id, txn_id);
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -6990,12 +6990,11 @@ TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_range_spl
 // information_schema.be_cloud_native_compactions PROFILE column from regressing
 // to a subtask-only payload that drops to_json_stats() output.
 TEST(TabletParallelCompactionManagerProfileTest, merge_subtask_info_preserves_stats) {
-    std::string stats =
-            R"({"read_local_sec":1,"read_local_mb":2,"read_remote_sec":3,"read_remote_mb":4,)"
-            R"("read_remote_count":5,"read_local_count":6})";
+    std::string stats = R"({"read_local_sec":1,"read_local_mb":2,"read_remote_sec":3,"read_remote_mb":4,)"
+                        R"("read_remote_count":5,"read_local_count":6})";
     std::string merged = TabletParallelCompactionManager::merge_subtask_info_into_stats_json(stats, /*subtask_id=*/2,
-                                                                                              /*input_rowsets=*/7,
-                                                                                              /*input_bytes=*/12345);
+                                                                                             /*input_rowsets=*/7,
+                                                                                             /*input_bytes=*/12345);
 
     // All original stats keys must still be present.
     EXPECT_NE(std::string::npos, merged.find(R"("read_local_sec":1)"));
@@ -7024,8 +7023,8 @@ TEST(TabletParallelCompactionManagerProfileTest, merge_subtask_info_with_empty_s
     // to_json_stats() always returns a JSON object; emulate the degenerate "{}" case
     // and make sure we don't emit a leading comma like {,"subtask_id":...}.
     std::string merged = TabletParallelCompactionManager::merge_subtask_info_into_stats_json("{}", /*subtask_id=*/0,
-                                                                                              /*input_rowsets=*/1,
-                                                                                              /*input_bytes=*/2);
+                                                                                             /*input_rowsets=*/1,
+                                                                                             /*input_bytes=*/2);
     EXPECT_EQ(R"({"subtask_id":0,"input_rowsets":1,"input_bytes":2,"is_parallel_subtask":true})", merged);
 }
 


### PR DESCRIPTION
## Why I'm doing:

The `information_schema.be_cloud_native_compactions` PROFILE column was regressing to contain only subtask-specific metadata, losing the valuable `CompactionTaskStats` information produced by `to_json_stats()`. This change ensures both the stats and subtask metadata are preserved in the profile.

## What I'm doing:

1. **Added `merge_subtask_info_into_stats_json()` method** to `TabletParallelCompactionManager` that intelligently combines:
   - The JSON stats object from `CompactionTaskStats::to_json_stats()` (read bytes, segment counts, etc.)
   - Subtask-specific fields (subtask_id, input_rowsets, input_bytes, is_parallel_subtask flag)
   - Handles edge cases: empty stats objects, missing/malformed JSON, and proper JSON structure

2. **Updated `list_tasks()` method** to:
   - Extract stats JSON from the running subtask's context if available
   - Use the new merge function to combine stats with subtask metadata
   - Replace the previous hardcoded subtask-only profile format

3. **Added comprehensive unit tests** covering:
   - Preservation of all original stats fields when merging
   - Proper JSON structure (single object, no double braces)
   - Empty stats object handling (no leading comma)
   - Malformed/missing stats fallback behavior
   - End-to-end integration test with actual `CompactionTaskStats` data

## What type of PR is this:

- [x] Enhancement
- [ ] UT

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: The PROFILE column in information_schema.be_cloud_native_compactions now includes both CompactionTaskStats and subtask metadata instead of just subtask metadata

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
  - Added 4 new unit tests: `merge_subtask_info_preserves_stats`, `merge_subtask_info_with_empty_stats_object`, `merge_subtask_info_with_missing_stats`, and `list_tasks_running_profile_contains_stats_and_subtask_info`
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

https://claude.ai/code/session_0181r7CBoPo4QUdyzAJ8iwPj