### PR TITLE
Remove input_bytes from parallel compaction subtask metadata

### DIFF
--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -118,15 +118,13 @@ std::string CompactionTaskStats::to_json_stats() const {
     return serialize(root);
 }
 
-std::string CompactionTaskStats::to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets,
-                                                                     int64_t input_bytes) const {
+std::string CompactionTaskStats::to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets) const {
     rapidjson::Document root;
     root.SetObject();
     fill_stats_fields(root, *this);
     auto& allocator = root.GetAllocator();
     root.AddMember("subtask_id", rapidjson::Value(subtask_id), allocator);
     root.AddMember("input_rowsets", rapidjson::Value(static_cast<int64_t>(input_rowsets)), allocator);
-    root.AddMember("input_bytes", rapidjson::Value(input_bytes), allocator);
     root.AddMember("is_parallel_subtask", rapidjson::Value(true), allocator);
     return serialize(root);
 }

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -66,11 +66,12 @@ struct CompactionTaskStats {
     std::string to_json_stats() const;
 
     // Same JSON layout as to_json_stats(), with parallel-subtask metadata fields
-    // (subtask_id, input_rowsets, input_bytes, is_parallel_subtask) appended.
-    // Used for the PROFILE column of be_cloud_native_compactions so that both
-    // the CompactionTaskStats counters and per-subtask metadata are visible.
-    std::string to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets,
-                                                    int64_t input_bytes) const;
+    // (subtask_id, input_rowsets, is_parallel_subtask) appended. Used for the
+    // PROFILE column of be_cloud_native_compactions so that both the
+    // CompactionTaskStats counters and per-subtask metadata are visible. Actual
+    // read volume is already reported via read_local_mb / read_remote_mb in the
+    // stats fields, so the planned input_bytes is intentionally omitted.
+    std::string to_json_stats_with_subtask_metadata(int32_t subtask_id, size_t input_rowsets) const;
 };
 
 // Context of a single tablet compaction task.
@@ -130,7 +131,6 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     // start so that the PROFILE column of be_cloud_native_compactions can keep reporting it
     // after the subtask leaves running_subtasks.
     int64_t subtask_input_rowsets = 0;
-    int64_t subtask_input_bytes = 0;
     // Flag to indicate this is a merged context from parallel compaction.
     // When true, cleanup_tablet should be called in remove_states after RPC response is sent.
     bool is_parallel_merged = false;

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1458,7 +1458,6 @@ void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t
             // Snapshot the subtask input footprint onto the context so list_tasks() can
             // surface it consistently for both running and completed subtasks.
             context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
-            context->subtask_input_bytes = it->second.input_bytes;
             // Store context pointer for real-time progress/status tracking
             it->second.context = context.get();
         }
@@ -1646,8 +1645,8 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
             if (subtask_info.context != nullptr && subtask_info.context->stats) {
                 stats_ptr = subtask_info.context->stats.get();
             }
-            info.profile = stats_ptr->to_json_stats_with_subtask_metadata(
-                    subtask_id, subtask_info.input_rowset_ids.size(), subtask_info.input_bytes);
+            info.profile =
+                    stats_ptr->to_json_stats_with_subtask_metadata(subtask_id, subtask_info.input_rowset_ids.size());
         }
 
         // Add completed subtasks that haven't been cleaned up yet
@@ -1667,7 +1666,7 @@ void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>
                 // parallel subtask.
                 if (ctx->subtask_id >= 0) {
                     info.profile = ctx->stats->to_json_stats_with_subtask_metadata(
-                            ctx->subtask_id, static_cast<size_t>(ctx->subtask_input_rowsets), ctx->subtask_input_bytes);
+                            ctx->subtask_id, static_cast<size_t>(ctx->subtask_input_rowsets));
                 } else {
                     info.profile = ctx->stats->to_json_stats();
                 }
@@ -2212,7 +2211,6 @@ void TabletParallelCompactionManager::execute_subtask_segment_range(int64_t tabl
             int64_t in_queue_time_sec = start_time > enqueue_time ? (start_time - enqueue_time) : 0;
             context->stats->in_queue_time_sec += in_queue_time_sec;
             context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
-            context->subtask_input_bytes = it->second.input_bytes;
             it->second.context = context.get();
         }
     }
@@ -2559,7 +2557,6 @@ void TabletParallelCompactionManager::execute_subtask_range_split(
             int64_t in_queue_time_sec = start_time > enqueue_time ? (start_time - enqueue_time) : 0;
             context->stats->in_queue_time_sec += in_queue_time_sec;
             context->subtask_input_rowsets = static_cast<int64_t>(it->second.input_rowset_ids.size());
-            context->subtask_input_bytes = it->second.input_bytes;
             it->second.context = context.get();
         }
     }

--- a/be/test/storage/lake/compaction_task_context_test.cpp
+++ b/be/test/storage/lake/compaction_task_context_test.cpp
@@ -165,7 +165,7 @@ TEST_F(CompactionTaskContextTest, test_to_json_stats_with_subtask_metadata) {
     context.stats->in_queue_time_sec = 11;
 
     std::string json_profile = context.stats->to_json_stats_with_subtask_metadata(
-            /*subtask_id=*/3, /*input_rowsets=*/5, /*input_bytes=*/2048);
+            /*subtask_id=*/3, /*input_rowsets=*/5);
 
     // Stats fields must still be present (this is the regression that was being lost).
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("read_remote_mb":2)"));
@@ -173,10 +173,12 @@ TEST_F(CompactionTaskContextTest, test_to_json_stats_with_subtask_metadata) {
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("write_segment_count":7)"));
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("in_queue_sec":11)"));
 
-    // Subtask metadata must be appended alongside the stats.
+    // Subtask metadata must be appended alongside the stats. The planned input_bytes
+    // is intentionally omitted because the actual read volume is already reported via
+    // read_local_mb / read_remote_mb in the stats fields above.
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("subtask_id":3)"));
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("input_rowsets":5)"));
-    EXPECT_THAT(json_profile, testing::HasSubstr(R"("input_bytes":2048)"));
+    EXPECT_THAT(json_profile, testing::Not(testing::HasSubstr(R"("input_bytes")")));
     EXPECT_THAT(json_profile, testing::HasSubstr(R"("is_parallel_subtask":true)"));
 }
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -1388,7 +1388,6 @@ TEST_F(TabletParallelCompactionManagerTest, test_list_tasks_with_completed) {
     ctx0->finish_time.store(::time(nullptr), std::memory_order_release);
     ctx0->skipped.store(false, std::memory_order_relaxed);
     ctx0->subtask_input_rowsets = 4;
-    ctx0->subtask_input_bytes = 1234;
     ctx0->stats->in_queue_time_sec = 7;
     ctx0->txn_log = std::make_unique<TxnLogPB>();
     ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
@@ -1411,7 +1410,7 @@ TEST_F(TabletParallelCompactionManagerTest, test_list_tasks_with_completed) {
             EXPECT_NE(info.profile.find(R"("in_queue_sec":7)"), std::string::npos);
             EXPECT_NE(info.profile.find(R"("subtask_id":0)"), std::string::npos);
             EXPECT_NE(info.profile.find(R"("input_rowsets":4)"), std::string::npos);
-            EXPECT_NE(info.profile.find(R"("input_bytes":1234)"), std::string::npos);
+            EXPECT_EQ(info.profile.find(R"("input_bytes")"), std::string::npos);
             EXPECT_NE(info.profile.find(R"("is_parallel_subtask":true)"), std::string::npos);
             found_completed_profile = true;
         }


### PR DESCRIPTION
## Why I'm doing:

The `input_bytes` field in parallel compaction subtask metadata is redundant. The actual read volume is already accurately reported via `read_local_mb` and `read_remote_mb` fields in the compaction stats. Including the planned `input_bytes` can be misleading since it may not reflect the actual bytes read due to compression, filtering, or other factors.

## What I'm doing:

Removes the `input_bytes` parameter and field from the parallel compaction subtask metadata:

1. **compaction_task_context.h**: 
   - Removed `input_bytes` parameter from `to_json_stats_with_subtask_metadata()` method signature
   - Removed `subtask_input_bytes` field from `CompactionTaskContext` struct
   - Updated comments to explain why `input_bytes` is intentionally omitted

2. **compaction_task_context.cpp**: 
   - Updated `to_json_stats_with_subtask_metadata()` implementation to not include `input_bytes` in JSON output

3. **tablet_parallel_compaction_manager.cpp**: 
   - Removed assignments to `context->subtask_input_bytes` in three execution methods
   - Updated all calls to `to_json_stats_with_subtask_metadata()` to remove the `input_bytes` argument

4. **Tests**: 
   - Updated `compaction_task_context_test.cpp` to verify `input_bytes` is NOT present in the output
   - Updated `tablet_parallel_compaction_manager_test.cpp` to verify the field is absent from completed task profiles

## What type of PR is this:

- [x] Enhancement
- [ ] BugFix
- [ ] Feature
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: The JSON profile output for parallel compaction subtasks no longer includes the `input_bytes` field

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

https://claude.ai/code/session_01XC7rbPaZ2jqxtPc7gjr4ws