### PR TITLE
[BugFix] Fix BACKUP ON (ALL FUNCTION) reporting database as empty

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2587,6 +2587,19 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
                     }
                 }
             });
+
+            if (statement.allFunction() && db != null) {
+                for (Function fn : db.getFunctions()) {
+                    try {
+                        Authorizer.checkFunctionAction(context, db, fn, PrivilegeType.USAGE);
+                    } catch (AccessDeniedException e) {
+                        AccessDeniedException.reportAccessDenied(
+                                InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
+                                context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
+                                PrivilegeType.DROP.name(), ObjectType.FUNCTION.name(), fn.getSignature());
+                    }
+                }
+            }
         } else {
             List<CatalogRef> externalCatalogs = statement.getExternalCatalogRefs();
             externalCatalogs.forEach(externalCatalog -> {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -2545,7 +2545,9 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
         if (!statement.containsExternalCatalog()) {
             List<TableRef> tableRefs = statement.getTableRefs();
             List<FunctionRef> functionRefs = statement.getFnRefs();
-            if (tableRefs.isEmpty() && functionRefs.isEmpty()) {
+            if (tableRefs.isEmpty() && functionRefs.isEmpty()
+                    && !statement.allTable() && !statement.allMV()
+                    && !statement.allView() && !statement.allFunction()) {
                 String dBName = statement.getDbName();
                 throw new SemanticException("Database: %s is empty", dBName);
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeBackupRestoreTest.java
@@ -101,6 +101,12 @@ public class AnalyzeBackupRestoreTest {
         analyzeSuccess("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo` ON " +
                 "( ALL FUNCTIONS, ALL TABLES, ALL VIEWS, ALL MATERIALIZED VIEWS ) " +
                 "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo` ON ( ALL FUNCTIONS ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP DATABASE test SNAPSHOT snapshot_label2 TO `repo` ON ( ALL FUNCTION ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
+        analyzeSuccess("BACKUP SNAPSHOT test.snapshot_label2 TO `repo` ON ( ALL FUNCTIONS ) " +
+                "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeSuccess("BACKUP ALL EXTERNAL CATALOGS SNAPSHOT snapshot_label2 TO `repo` " +
                        "PROPERTIES (\"type\" = \"full\",\"timeout\" = \"3600\");");
         analyzeSuccess("BACKUP EXTERNAL CATALOG (catalog1) SNAPSHOT snapshot_label2 TO `repo` " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -2514,19 +2514,56 @@ public class PrivilegeCheckerTest extends StarRocksTestBase {
     @Test
     public void testBackupAllFunctionStmt() throws Exception {
         mockRepository();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        FunctionName fn = FunctionName.createFnName("db1.backup_all_fn_udf");
+        Function function = new ScalarFunction(fn,
+                Arrays.asList(StringType.STRING), StringType.STRING, false);
+        try {
+            db1.addFunction(function);
+        } catch (Throwable e) {
+            // ignore
+        }
+
         ctxToRoot();
         grantOrRevoke("grant repository on system to test");
         ctxToTestUser();
-        for (String sql : new String[] {
+
+        String[] sqls = new String[] {
                 "BACKUP SNAPSHOT db1.backup_name1 TO example_repo ON (ALL FUNCTIONS) PROPERTIES ('type' = 'full');",
                 "BACKUP SNAPSHOT db1.backup_name1 TO example_repo ON (ALL FUNCTION) PROPERTIES ('type' = 'full');",
                 "BACKUP DATABASE db1 SNAPSHOT backup_name1 TO example_repo ON (ALL FUNCTIONS) " +
-                        "PROPERTIES ('type' = 'full');"}) {
+                        "PROPERTIES ('type' = 'full');"};
+
+        // Without USAGE on the function the check must fail (no more "Database is empty" misfire).
+        String expectError = "Access denied; you need (at least one of) the USAGE privilege(s) on FUNCTION";
+        for (String sql : sqls) {
+            StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            try {
+                Authorizer.check(statement, starRocksAssert.getCtx());
+                Assertions.fail("expected access denied for: " + sql);
+            } catch (Exception e) {
+                logSysInfo(e.getMessage() + ", sql: " + sql);
+                Assertions.assertTrue(e.getMessage().contains(expectError), e.getMessage());
+            }
+        }
+
+        // Granting USAGE on ALL FUNCTIONS in db1 lets the check pass.
+        ctxToRoot();
+        grantOrRevoke("grant usage on ALL FUNCTIONS in database db1 to test");
+        ctxToTestUser();
+        for (String sql : sqls) {
             StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
             Authorizer.check(statement, starRocksAssert.getCtx());
         }
+
         ctxToRoot();
+        grantOrRevoke("revoke usage on ALL FUNCTIONS in database db1 from test");
         grantOrRevoke("revoke repository on system from test");
+        try {
+            db1.dropFunctionForRestore(function);
+        } catch (Throwable e) {
+            // ignore
+        }
         ctxToTestUser();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -2512,6 +2512,25 @@ public class PrivilegeCheckerTest extends StarRocksTestBase {
     }
 
     @Test
+    public void testBackupAllFunctionStmt() throws Exception {
+        mockRepository();
+        ctxToRoot();
+        grantOrRevoke("grant repository on system to test");
+        ctxToTestUser();
+        for (String sql : new String[] {
+                "BACKUP SNAPSHOT db1.backup_name1 TO example_repo ON (ALL FUNCTIONS) PROPERTIES ('type' = 'full');",
+                "BACKUP SNAPSHOT db1.backup_name1 TO example_repo ON (ALL FUNCTION) PROPERTIES ('type' = 'full');",
+                "BACKUP DATABASE db1 SNAPSHOT backup_name1 TO example_repo ON (ALL FUNCTIONS) " +
+                        "PROPERTIES ('type' = 'full');"}) {
+            StatementBase statement = UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+            Authorizer.check(statement, starRocksAssert.getCtx());
+        }
+        ctxToRoot();
+        grantOrRevoke("revoke repository on system from test");
+        ctxToTestUser();
+    }
+
+    @Test
     public void testShowBackupStmtInShowExecutor() throws Exception {
 
         mockAddBackupJob("db1");


### PR DESCRIPTION
When running `BACKUP DATABASE <db> SNAPSHOT <s> TO <repo> ON (ALL FUNCTION)`, the authorizer rejected the statement with "Database: <db> is empty" even though the database contained UDFs.

`AstBuilder` records `ALL FUNCTION` in `allMarker` without populating the `fnRefs` list (only individually named functions go into `fnRefs`). The analyzer correctly honors `allFunction()`, but `AuthorizerStmtVisitor` only inspected the ref lists and not `allMarker`, so the statement was rejected before the analyzer's expansion logic could run.

`ALL TABLE`/`ALL MV`/`ALL VIEW` happened to slip past because the analyzer pre-fills `tblRefs` with all tables of the corresponding type during analysis, so the ref list was non-empty by the time the authorizer ran. `ALL FUNCTION` is expanded later in `BackupHandler`, leaving both lists empty during authorization.

Extend the empty check to also consider the `allMarker` flags. Add analyzer coverage for `ON (ALL FUNCTION)` alone and an authorizer-level test that exercises `Authorizer.check` for the same statements to guard against future regressions.

## Why I'm doing:

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
