### PR TITLE
[Feature] Add informational notice for DELETE on non-Primary-Key tables

### DIFF
--- a/docs/en/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/management/FE_parameters/user_query_loading.md
@@ -530,6 +530,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The maximum number of elements allowed for the IN predicate in a DELETE statement.
 - Introduced in: -
 
+### `enable_non_primary_key_delete_warning`
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When set to `true`, a successful `DELETE` against a non-Primary-Key OLAP table (Duplicate Key, Aggregate, Unique Key) returns an informational notice in the MySQL OK packet's `info` field, reminding the user that `DELETE` writes delete predicates and incurs merge-on-read cost until base compaction runs, and recommending `ALTER TABLE ... TRUNCATE PARTITION` for bulk partition removal. Set to `false` to suppress the notice. The notice does not change DELETE semantics or affect execution; it only adds an info string visible to the client. See [DELETE](../../../sql-reference/sql-statements/table_bucket_part_index/DELETE.md) for context.
+- Introduced in: -
+
 ### `max_create_table_timeout_second`
 
 - Default: 600

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/DELETE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/DELETE.md
@@ -64,6 +64,8 @@ ALTER TABLE <table_name> TRUNCATE PARTITION (<partition_name>);
 
 [`TRUNCATE PARTITION`](TRUNCATE_TABLE.md) drops the partition's data immediately by replacing its rowsets with an empty version, without producing delete markers and without waiting for compaction.
 
+If your workload issues `DELETE` **frequently** (rather than as a one-off bulk cleanup), consider modeling the table as a **Primary Key table** instead. Primary Key tables support row-level deletes with delete-vector / merge-on-write semantics and do not incur the per-read merge-on-read penalty of Duplicate / Aggregate / Unique Key tables.
+
 Starting from this version, StarRocks returns a notice in the MySQL OK packet's `info` field when `DELETE` runs against a Duplicate / Aggregate / Unique Key table to remind you of this trade-off. The notice can be turned off by setting the FE configuration `enable_non_primary_key_delete_warning` to `false`.
 
 :::

--- a/docs/en/sql-reference/sql-statements/table_bucket_part_index/DELETE.md
+++ b/docs/en/sql-reference/sql-statements/table_bucket_part_index/DELETE.md
@@ -50,6 +50,24 @@ column_name1 op { value | value_list } [ AND column_name2 op { value | value_lis
 
 After you execute the DELETE statement, the query performance of your cluster may deteriorate for a period of time (before compaction is completed). The degree of deterioration varies based on the number of conditions that you specify. A larger number of conditions indicates a higher degree of deterioration.
 
+:::warning Bulk removal: prefer `TRUNCATE PARTITION` over `DELETE`
+
+On Duplicate Key, Aggregate, and Unique Key tables, `DELETE` does **not** physically remove rows. It writes a delete predicate (a "delete marker") attached to a new tablet version. Every subsequent read must scan the affected tablets, evaluate the delete predicates per row, and merge the result on the fly (merge-on-read). This cost persists until base compaction merges the delete predicates with the base data.
+
+If a partition has no new writes after `DELETE`, base compaction may not be triggered until `base_compaction_interval_seconds_since_last_operation` elapses (24 hours by default), so the merge-on-read penalty can stay active for a long time. For tables with hundreds of partitions and thousands of tablets, a simple `SELECT ... LIMIT 1` can become orders of magnitude slower or even time out.
+
+For bulk removal of entire partitions (for example, during historical-data migration), prefer:
+
+```SQL
+ALTER TABLE <table_name> TRUNCATE PARTITION (<partition_name>);
+```
+
+[`TRUNCATE PARTITION`](TRUNCATE_TABLE.md) drops the partition's data immediately by replacing its rowsets with an empty version, without producing delete markers and without waiting for compaction.
+
+Starting from this version, StarRocks returns a notice in the MySQL OK packet's `info` field when `DELETE` runs against a Duplicate / Aggregate / Unique Key table to remind you of this trade-off. The notice can be turned off by setting the FE configuration `enable_non_primary_key_delete_warning` to `false`.
+
+:::
+
 ### Examples
 
 #### Create a table and insert data

--- a/docs/zh/administration/management/FE_parameters/user_query_loading.md
+++ b/docs/zh/administration/management/FE_parameters/user_query_loading.md
@@ -530,6 +530,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: DELETE 语句中 IN 谓词允许的最大元素数量。
 - 引入版本: -
 
+### `enable_non_primary_key_delete_warning`
+
+- 默认值: true
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 当设置为 `true` 时，对非主键 OLAP 表（明细表、聚合表、更新表）执行成功的 `DELETE` 后，StarRocks 会在 MySQL OK 包的 `info` 字段中返回一条提示，提醒用户 `DELETE` 会写入删除谓词、在 base compaction 完成前每次查询都需要 merge-on-read，并建议批量按分区删除时改用 `ALTER TABLE ... TRUNCATE PARTITION`。设置为 `false` 可关闭此提示。该提示不会改变 DELETE 的语义或执行流程，只是额外向客户端返回一段 info 字符串。详见 [DELETE](../../../sql-reference/sql-statements/table_bucket_part_index/DELETE.md)。
+- 引入版本: -
+
 ### `max_create_table_timeout_second`
 
 - 默认值: 600

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/DELETE.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/DELETE.md
@@ -62,6 +62,8 @@ ALTER TABLE <table_name> TRUNCATE PARTITION (<partition_name>);
 
 [`TRUNCATE PARTITION`](TRUNCATE_TABLE.md) 通过把分区的 rowset 直接替换为空版本来立即释放数据，不会产生删除标记，也无需等待 compaction。
 
+如果业务场景需要**频繁** DELETE（而不是一次性批量清理），建议直接把表建成**主键表（Primary Key 表）**。主键表通过 delete vector / merge-on-write 实现行级删除，不会引入明细表、聚合表、更新表那样的 merge-on-read 代价。
+
 从该版本开始，对明细表、聚合表、更新表执行 `DELETE` 成功后，StarRocks 会在 MySQL OK 包的 `info` 字段中返回一条提示，提醒用户上述代价。如需关闭该提示，可将 FE 配置 `enable_non_primary_key_delete_warning` 设为 `false`。
 
 :::

--- a/docs/zh/sql-reference/sql-statements/table_bucket_part_index/DELETE.md
+++ b/docs/zh/sql-reference/sql-statements/table_bucket_part_index/DELETE.md
@@ -48,6 +48,24 @@ column_name1 op { value | value_list } [ AND column_name2 op { value | value_lis
 
 执行 DELETE 语句后，可能会导致接下来一段时间内（Compaction 完成之前）的查询效率降低。影响程度取决于语句中指定的删除条件的数量。指定的条件越多，影响越大。
 
+:::warning 批量删除分区数据请优先使用 `TRUNCATE PARTITION`
+
+在明细表、聚合表、更新表上执行 `DELETE` **不会立即物理删除数据**，只会在 Tablet 上写入一个新的版本及对应的删除谓词（delete predicate / 删除标记）。在 Base Compaction 把删除谓词与基线数据合并之前，每一次读取都要扫描受影响的 Tablet，逐行评估删除谓词、实时合并结果（merge-on-read），因此这段时间内查询性能会显著下降。
+
+如果分区在 DELETE 之后没有新写入触发增量 compaction，BE 只能依赖时间阈值 `base_compaction_interval_seconds_since_last_operation`（默认 24 小时）来触发 base compaction，merge-on-read 的代价可能长时间无法消除。在分区数和 Tablet 数较多的大表上（例如几百个分区、几千个 Tablet），即使 `SELECT ... LIMIT 1` 也可能变慢甚至超时。
+
+如果是按整个分区批量清理数据（例如历史数据迁移），推荐使用：
+
+```SQL
+ALTER TABLE <table_name> TRUNCATE PARTITION (<partition_name>);
+```
+
+[`TRUNCATE PARTITION`](TRUNCATE_TABLE.md) 通过把分区的 rowset 直接替换为空版本来立即释放数据，不会产生删除标记，也无需等待 compaction。
+
+从该版本开始，对明细表、聚合表、更新表执行 `DELETE` 成功后，StarRocks 会在 MySQL OK 包的 `info` 字段中返回一条提示，提醒用户上述代价。如需关闭该提示，可将 FE 配置 `enable_non_primary_key_delete_warning` 设为 `false`。
+
+:::
+
 ### 示例
 
 #### 创建表并插入数据

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1536,6 +1536,14 @@ public class Config extends ConfigBase {
     public static int max_allowed_in_element_num_of_delete = 10000;
 
     /**
+     * When true, DELETE on a non-Primary-Key OLAP table (Duplicate / Aggregate / Unique Key)
+     * returns an OK-packet info message reminding the user that DELETE writes delete markers
+     * (merge-on-read) and recommending ALTER TABLE ... TRUNCATE PARTITION for bulk removal.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_non_primary_key_delete_warning = true;
+
+    /**
      * control materialized view
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -3189,8 +3189,14 @@ public class StmtExecutor {
         // special handling for delete of non-primary key table, using old handler
         if (stmt instanceof DeleteStmt && ((DeleteStmt) stmt).shouldHandledByDeleteHandler()) {
             try {
-                context.getGlobalStateMgr().getDeleteMgr().process((DeleteStmt) stmt);
-                context.getState().setOk();
+                DeleteStmt deleteStmt = (DeleteStmt) stmt;
+                context.getGlobalStateMgr().getDeleteMgr().process(deleteStmt);
+                String okInfo = deleteStmt.getOkInfoMessage();
+                if (okInfo != null && !okInfo.isEmpty()) {
+                    context.getState().setOk(0, 0, okInfo);
+                } else {
+                    context.getState().setOk();
+                }
             } catch (QueryStateException e) {
                 if (e.getQueryState().getStateType() != MysqlStateType.OK) {
                     LOG.warn("DDL statement({}) process failed.", getRedactedOriginStmtInString(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DeleteAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DeleteAnalyzer.java
@@ -156,6 +156,29 @@ public class DeleteAnalyzer {
         }
     }
 
+    private static String buildNonPrimaryKeyDeleteInfo(OlapTable table) {
+        String keysTypeName;
+        switch (table.getKeysType()) {
+            case DUP_KEYS:
+                keysTypeName = "Duplicate Key";
+                break;
+            case AGG_KEYS:
+                keysTypeName = "Aggregate";
+                break;
+            case UNIQUE_KEYS:
+                keysTypeName = "Unique Key";
+                break;
+            default:
+                keysTypeName = table.getKeysType().name();
+                break;
+        }
+        return "DELETE on " + keysTypeName + " table '" + table.getName() + "' writes delete predicates; "
+                + "rows remain physically present and every read pays a merge-on-read cost until base "
+                + "compaction runs. For bulk removal of whole partitions, prefer "
+                + "ALTER TABLE ... TRUNCATE PARTITION, which drops data immediately. "
+                + "(Disable this notice with FE config enable_non_primary_key_delete_warning=false.)";
+    }
+
     private static void analyzeNonPrimaryKey(DeleteStmt deleteStatement) {
         PartitionRef partitionNames = deleteStatement.getPartitionNames();
         if (partitionNames != null) {
@@ -286,6 +309,9 @@ public class DeleteAnalyzer {
         }
 
         if (!(table instanceof OlapTable && ((OlapTable) table).getKeysType() == KeysType.PRIMARY_KEYS)) {
+            if (table instanceof OlapTable && Config.enable_non_primary_key_delete_warning) {
+                deleteStatement.setOkInfoMessage(buildNonPrimaryKeyDeleteInfo((OlapTable) table));
+            }
             analyzeNonPrimaryKey(deleteStatement);
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DeleteAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DeleteAnalyzer.java
@@ -176,6 +176,8 @@ public class DeleteAnalyzer {
                 + "rows remain physically present and every read pays a merge-on-read cost until base "
                 + "compaction runs. For bulk removal of whole partitions, prefer "
                 + "ALTER TABLE ... TRUNCATE PARTITION, which drops data immediately. "
+                + "If your workload issues DELETE frequently, consider switching to a Primary Key table, "
+                + "which supports row-level deletes without merge-on-read. "
                 + "(Disable this notice with FE config enable_non_primary_key_delete_warning=false.)";
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DeleteStmt.java
@@ -59,6 +59,11 @@ public class DeleteStmt extends DmlStmt {
     // The JobID is generated here for easy correlation when cancel Delete
     private long jobId = -1;
 
+    // Optional MySQL OK-packet info string attached at analyze time, surfaced to the
+    // client after DeleteMgr.process() succeeds. Used to warn about merge-on-read cost
+    // on non-Primary-Key tables and recommend TRUNCATE PARTITION for bulk removal.
+    private String okInfoMessage;
+
     public DeleteStmt(TableRef tableRef, PartitionRef partitionNames, Expr wherePredicate) {
         this(tableRef, partitionNames, null, wherePredicate, null, NodePosition.ZERO);
     }
@@ -143,6 +148,14 @@ public class DeleteStmt extends DmlStmt {
 
     public QueryStatement getQueryStatement() {
         return queryStatement;
+    }
+
+    public String getOkInfoMessage() {
+        return okInfoMessage;
+    }
+
+    public void setOkInfoMessage(String okInfoMessage) {
+        this.okInfoMessage = okInfoMessage;
     }
 
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDeleteTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.starrocks.common.Config;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
@@ -93,5 +94,48 @@ public class AnalyzeDeleteTest {
         analyzeSuccess(
                 "with tp2cte as (select * from tprimary2 where v2 < 10) delete from tprimary using " +
                         "tp2cte where tprimary.pk = tp2cte.pk");
+    }
+
+    @Test
+    public void testNonPrimaryKeyDeleteEmitsOkInfo() {
+        boolean original = Config.enable_non_primary_key_delete_warning;
+        try {
+            Config.enable_non_primary_key_delete_warning = true;
+            DeleteStmt stmt = (DeleteStmt) analyzeSuccess("delete from tjson where v_int = 1");
+            String info = stmt.getOkInfoMessage();
+            Assertions.assertNotNull(info, "Duplicate Key DELETE should attach an OK info message");
+            Assertions.assertTrue(info.contains("Duplicate Key"),
+                    "info should name the keys type: " + info);
+            Assertions.assertTrue(info.contains("TRUNCATE PARTITION"),
+                    "info should recommend TRUNCATE PARTITION: " + info);
+        } finally {
+            Config.enable_non_primary_key_delete_warning = original;
+        }
+    }
+
+    @Test
+    public void testPrimaryKeyDeleteDoesNotEmitOkInfo() {
+        boolean original = Config.enable_non_primary_key_delete_warning;
+        try {
+            Config.enable_non_primary_key_delete_warning = true;
+            DeleteStmt stmt = (DeleteStmt) analyzeSuccess("delete from tprimary where pk = 1");
+            Assertions.assertNull(stmt.getOkInfoMessage(),
+                    "Primary Key DELETE should not attach an OK info message");
+        } finally {
+            Config.enable_non_primary_key_delete_warning = original;
+        }
+    }
+
+    @Test
+    public void testNonPrimaryKeyDeleteWarningCanBeDisabled() {
+        boolean original = Config.enable_non_primary_key_delete_warning;
+        try {
+            Config.enable_non_primary_key_delete_warning = false;
+            DeleteStmt stmt = (DeleteStmt) analyzeSuccess("delete from tjson where v_int = 1");
+            Assertions.assertNull(stmt.getOkInfoMessage(),
+                    "OK info should be suppressed when the FE config knob is off");
+        } finally {
+            Config.enable_non_primary_key_delete_warning = original;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDeleteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDeleteTest.java
@@ -108,6 +108,8 @@ public class AnalyzeDeleteTest {
                     "info should name the keys type: " + info);
             Assertions.assertTrue(info.contains("TRUNCATE PARTITION"),
                     "info should recommend TRUNCATE PARTITION: " + info);
+            Assertions.assertTrue(info.contains("Primary Key"),
+                    "info should recommend Primary Key table for frequent deletes: " + info);
         } finally {
             Config.enable_non_primary_key_delete_warning = original;
         }


### PR DESCRIPTION
## Why I'm doing:

DELETE operations on non-Primary-Key OLAP tables (Duplicate Key, Aggregate, Unique Key) write delete predicates rather than physically removing rows. This incurs a merge-on-read cost on every subsequent read until base compaction runs, which can significantly impact query performance. Users should be aware of this trade-off and consider alternatives like `TRUNCATE PARTITION` for bulk removal or migrating to Primary Key tables for frequent deletes.

## What I'm doing:

This PR adds an informational notice that is returned to clients when a DELETE statement successfully executes against a non-Primary-Key OLAP table. The notice:

1. Explains that DELETE writes delete predicates (not physical deletion)
2. Warns about the merge-on-read cost until base compaction
3. Recommends `ALTER TABLE ... TRUNCATE PARTITION` for bulk partition removal
4. Recommends Primary Key tables for workloads with frequent deletes
5. Can be disabled via the FE configuration `enable_non_primary_key_delete_warning`

### Changes:

- **DeleteStmt.java**: Added `okInfoMessage` field and getter/setter to carry the notice message
- **DeleteAnalyzer.java**: Added `buildNonPrimaryKeyDeleteInfo()` method to construct the notice message and set it on the DeleteStmt when analyzing non-Primary-Key deletes (if the config is enabled)
- **StmtExecutor.java**: Modified DELETE execution to pass the `okInfoMessage` to the MySQL OK packet's info field
- **Config.java**: Added `enable_non_primary_key_delete_warning` configuration (default: true, mutable)
- **AnalyzeDeleteTest.java**: Added three test cases covering the notice behavior
- **Documentation**: Updated DELETE statement documentation in both English and Chinese with detailed explanation of the merge-on-read cost and recommendations

## What type of PR is this:

- [x] Feature
- [ ] BugFix
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: MySQL OK packet info field now contains a notice message
- [x] Parameter changes: New FE configuration `enable_non_primary_key_delete_warning` (default: true)
- [ ] Policy changes
- [ ] Feature removed
- [ ] Miscellaneous

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
  - Added `testNonPrimaryKeyDeleteEmitsOkInfo()` to verify notice is generated for non-Primary-Key tables
  - Added `testPrimaryKeyDeleteDoesNotEmitOkInfo()` to verify no notice for Primary Key tables
  - Added `testNonPrimaryKeyDeleteWarningCanBeDisabled()` to verify config disables the notice
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
    - Updated `docs/en/sql-reference/sql-statements/table_bucket_part_index/DELETE.md`
    - Updated `docs/zh/sql-reference/sql-statements/table_bucket_part_index/DELETE.md`
    - Updated `docs/en/administration/management/FE_parameters/user_query_loading.md`
    - Updated `docs/zh/administration/management/FE_parameters/user_query_loading.md`
- [ ] This is a backport pr

https://claude.ai/code/session_011Gqom6QAYJBt1XRYM6MWRj