### PR TITLE
[BugFix] Hold the table WRITE lock in LakeTableIndexFastPathJobBase.replay()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableIndexFastPathJobBase.java
@@ -474,51 +474,66 @@ public abstract class LakeTableIndexFastPathJobBase extends AlterJobV2 {
         if (table == null) {
             return;
         }
-        if (jobState == JobState.PENDING || jobState == JobState.WAITING_TXN
-                || jobState == JobState.RUNNING) {
-            table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
-        } else if (jobState == JobState.FINISHED_REWRITING) {
-            table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
-            // The live runRunningJob bumped each partition's nextVersion to
-            // commitVersion+1 at the FINISHED_REWRITING transition (see
-            // updateNextVersion). The edit log persists the job's state but
-            // NOT that in-memory catalog bump, so a cold-started or
-            // leader-switched FE must redo it here. Without this the
-            // partition's nextVersion stays one behind the version reserved
-            // here, and the next operation that asserts
-            // nextVersion == its own reserved commitVersion -- e.g. a
-            // following LakeTableSchemaChangeJob.replay() -> updateNextVersion
-            // -- fails its Preconditions.checkState and aborts journal replay,
-            // leaving the FE unable to start.
-            replayUpdateNextVersion(table);
-        } else if (jobState == JobState.FINISHED) {
-            // Reapply catalog mutation at replay so a cold-started FE sees
-            // the post-alter table state. The mutation is idempotent by
-            // design (add checks presence, drop is no-op on missing).
-            //
-            // Also re-bump each partition's nextVersion and visibleVersion:
-            // the live FE captured both in memory only, and the next image may
-            // have been taken before the bump landed (or before the
-            // FINISHED_REWRITING journal that carries the nextVersion bump).
-            // Both bumps are idempotent: skip a partition that already
-            // advanced past the target (replay-after-checkpoint, or a later
-            // op that moved the version on).
-            replayUpdateNextVersion(table);
-            for (Map.Entry<Long, Long> e : commitVersionMap.entrySet()) {
-                PhysicalPartition pp = table.getPhysicalPartition(e.getKey());
-                if (pp != null && pp.getVisibleVersion() < e.getValue()) {
-                    pp.setVisibleVersion(e.getValue(), finishedTimeMs);
+        // Replay runs on followers/observers that serve reads concurrently
+        // with journal apply (and off the image on a cold-started or
+        // leader-switched FE). The per-partition version writes
+        // (replayUpdateNextVersion / setVisibleVersion) and the index-list
+        // mutation (applyCatalogMutation) touch shared OlapTable state, so
+        // they must be done under the table WRITE lock -- exactly as the live
+        // path (runRunningJob / runFinishedRewritingJob) and the sibling
+        // LakeTableAlterMetaJobBase.replay() already do. Acquire the lock
+        // before the try so a failed lock() does not run unLock() in finally.
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.WRITE);
+        try {
+            if (jobState == JobState.PENDING || jobState == JobState.WAITING_TXN
+                    || jobState == JobState.RUNNING) {
+                table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+            } else if (jobState == JobState.FINISHED_REWRITING) {
+                table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+                // The live runRunningJob bumped each partition's nextVersion to
+                // commitVersion+1 at the FINISHED_REWRITING transition (see
+                // updateNextVersion). The edit log persists the job's state but
+                // NOT that in-memory catalog bump, so a cold-started or
+                // leader-switched FE must redo it here. Without this the
+                // partition's nextVersion stays one behind the version reserved
+                // here, and the next operation that asserts
+                // nextVersion == its own reserved commitVersion -- e.g. a
+                // following LakeTableSchemaChangeJob.replay() -> updateNextVersion
+                // -- fails its Preconditions.checkState and aborts journal replay,
+                // leaving the FE unable to start.
+                replayUpdateNextVersion(table);
+            } else if (jobState == JobState.FINISHED) {
+                // Reapply catalog mutation at replay so a cold-started FE sees
+                // the post-alter table state. The mutation is idempotent by
+                // design (add checks presence, drop is no-op on missing).
+                //
+                // Also re-bump each partition's nextVersion and visibleVersion:
+                // the live FE captured both in memory only, and the next image may
+                // have been taken before the bump landed (or before the
+                // FINISHED_REWRITING journal that carries the nextVersion bump).
+                // Both bumps are idempotent: skip a partition that already
+                // advanced past the target (replay-after-checkpoint, or a later
+                // op that moved the version on).
+                replayUpdateNextVersion(table);
+                for (Map.Entry<Long, Long> e : commitVersionMap.entrySet()) {
+                    PhysicalPartition pp = table.getPhysicalPartition(e.getKey());
+                    if (pp != null && pp.getVisibleVersion() < e.getValue()) {
+                        pp.setVisibleVersion(e.getValue(), finishedTimeMs);
+                    }
                 }
+                applyCatalogMutation(table);
+                table.setState(OlapTable.OlapTableState.NORMAL);
+            } else if (jobState == JobState.CANCELLED) {
+                // A job force-cancelled out of FINISHED_REWRITING has already
+                // reserved a commitVersion and bumped nextVersion on the live FE;
+                // reproduce that bump on replay too (no-op when the job was
+                // cancelled before reserving, since commitVersionMap is empty).
+                replayUpdateNextVersion(table);
+                table.setState(OlapTable.OlapTableState.NORMAL);
             }
-            applyCatalogMutation(table);
-            table.setState(OlapTable.OlapTableState.NORMAL);
-        } else if (jobState == JobState.CANCELLED) {
-            // A job force-cancelled out of FINISHED_REWRITING has already
-            // reserved a commitVersion and bumped nextVersion on the live FE;
-            // reproduce that bump on replay too (no-op when the job was
-            // cancelled before reserving, since commitVersionMap is empty).
-            replayUpdateNextVersion(table);
-            table.setState(OlapTable.OlapTableState.NORMAL);
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tableId), LockType.WRITE);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

`LakeTableIndexFastPathJobBase.replay()` mutates shared `OlapTable` state with **no lock held**: per-partition `nextVersion`/`visibleVersion` (`replayUpdateNextVersion` / `setVisibleVersion`), the table index list (`applyCatalogMutation`), and `setState`.

The journal-replay dispatch path holds no db/table lock at any layer (`GlobalStateMgr.replayJournalInner` → `EditLog.loadJournal` → `AlterHandler.replayAlterJobV2` → `AlterJobV2.replay`), so on followers/observers that serve reads while applying the journal, these mutations race with readers holding the table READ lock. In particular `applyCatalogMutation` mutates the partition index collections (`PhysicalPartition.getAllMaterializedIndices` iterates the live `idToVisibleIndex`, and `MaterializedIndex.getTablets()` returns the live list), which a concurrent reader may be iterating → torn reads / `ConcurrentModificationException`. The `applyCatalogMutation` part has been unlocked since the feature was introduced; #74468 added the version writes into the same unlocked region.

Every other `AlterJobV2.replay()` in the codebase already holds a WRITE lock around its catalog mutations — table-WRITE in `LakeTableAlterMetaJobBase`, `SchemaChangeJobV2`, `RollupJobV2`, `OptimizeJobV2`, `MergePartitionJob`; db-WRITE in `LakeTableSchemaChangeJob`, `LakeRollupJob`, `OnlineOptimizeJobV2`. This job is the only exception.

## What I'm doing:

Wrap the state-branch logic of `replay()` in `lockTablesWithIntensiveDbLock(WRITE)`, mirroring the live path (`runRunningJob` / `runFinishedRewritingJob`) and the sibling `LakeTableAlterMetaJobBase.replay()`. The lock is acquired before the `try` so a failed `lock()` does not run `unLock()` in `finally`. The job-field copies stay outside the lock (consistent with the other jobs). No logic change otherwise.

**No deadlock risk:** nothing inside the locked region acquires another lock (`applyCatalogMutation` only mutates in-memory `OlapTable` structures), the replayer holds no other lock on entry, and the live path already wraps a superset of these operations in the same lock.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

> Note: existing replay unit tests in `LakeTableIndexFastPathJobBaseTest` (added in #74468) still cover the branch logic and pass with the lock held (the lock is keyed by `dbId`/`tableId`, independent of the mocked table object). Concurrency itself is not deterministically unit-testable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6xy3VNwvzwKZrAYeiL1iL)_